### PR TITLE
Remove ngcc from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "deploy:functions": "firebase deploy",
         "serve:playground": "cd apps/functions/src && http-server",
         "format:everything": "prettier --write .",
-        "install:all": "npm ci && husky install && node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main",
+        "install:all": "npm ci && husky install && node ./decorate-angular-cli.js",
         "analyze": "webpack-bundle-analyzer public/stats.json"
     },
     "main": "dist/apps/functions/main.js",


### PR DESCRIPTION
As of Angular 16, the Angular compiler does not need to be invoked in scripts