### PR TITLE
feat: admin revoke enrollment with Braintree refund

### DIFF
--- a/apps/functions-integration-tests/src/tests/revoke-enrollment.spec.ts
+++ b/apps/functions-integration-tests/src/tests/revoke-enrollment.spec.ts
@@ -1,0 +1,325 @@
+import {
+    createTestUser,
+    clearAuthEmulator,
+    clearFirestoreEmulator,
+    setFirestoreDoc,
+    callFunction,
+    FirestoreRef,
+    FirestoreTimestamp,
+} from '../utils';
+import type { TestUser } from '../utils';
+import { ADMIN_USER, NON_ADMIN_USER } from '../fixtures';
+import type {
+    RevokeEnrollmentRequest,
+    RevokeEnrollmentResponse,
+} from '@sol/ts/firebase/api-types';
+import type { SemesterEnrollment } from '@sol/classes/domain';
+
+const SEMESTER_ID = 'test-semester-revoke';
+
+const futureDate = new Date();
+futureDate.setFullYear(futureDate.getFullYear() + 1);
+
+const pastDate = new Date();
+pastDate.setFullYear(pastDate.getFullYear() - 1);
+
+function makeClassDoc(overrides: Record<string, unknown> = {}) {
+    return {
+        name: 'Test Class',
+        description: 'A test class',
+        live: true,
+        cost: 100,
+        location: 'Room A',
+        weekday: 'Monday',
+        daily_times: '9:00 AM - 12:00 PM',
+        class_type: 'Standard',
+        grade_range_start: 1,
+        grade_range_end: 5,
+        thumbnailUrl: '',
+        paused_for_enrollment: false,
+        for_information_only: false,
+        max_student_size: 12,
+        min_student_size: 5,
+        instructors: [],
+        students: [],
+        start: new FirestoreTimestamp(pastDate),
+        end: new FirestoreTimestamp(futureDate),
+        registration_end_date: new FirestoreTimestamp(futureDate),
+        ...overrides,
+    };
+}
+
+function makeEnrollmentDoc(
+    userId: string,
+    overrides: Record<string, unknown> = {}
+) {
+    return {
+        userId,
+        studentName: 'Test Student',
+        contactEmail: 'parent@test.com',
+        studentId: 'student-1',
+        finalCost: 100,
+        discountIds: [],
+        discounts: [],
+        classes: [{ id: 'class-1', semesterId: SEMESTER_ID }],
+        additionalOptionIdsByClassId: {},
+        status: 'enrolled',
+        transactionId: 'emulator-mock-txn',
+        timestamp: new FirestoreTimestamp(new Date()),
+        ...overrides,
+    };
+}
+
+describe('Revoke Enrollment', () => {
+    let adminUser: TestUser;
+    let nonAdminUser: TestUser;
+
+    beforeAll(async () => {
+        await clearAuthEmulator();
+        await clearFirestoreEmulator();
+
+        adminUser = await createTestUser(
+            ADMIN_USER.email,
+            ADMIN_USER.password
+        );
+        nonAdminUser = await createTestUser(
+            NON_ADMIN_USER.email,
+            NON_ADMIN_USER.password
+        );
+
+        await setFirestoreDoc('admins', adminUser.uid, {
+            userId: adminUser.uid,
+            email: adminUser.email,
+        });
+    });
+
+    beforeEach(async () => {
+        await clearFirestoreEmulator();
+        await setFirestoreDoc('admins', adminUser.uid, {
+            userId: adminUser.uid,
+            email: adminUser.email,
+        });
+    });
+
+    afterAll(async () => {
+        await clearAuthEmulator();
+        await clearFirestoreEmulator();
+    });
+
+    describe('Auth guard', () => {
+        it('should reject unauthenticated requests', async () => {
+            const result = await callFunction<RevokeEnrollmentRequest>({
+                functionName: 'revokeEnrollment',
+                data: { enrollmentId: 'some-id' },
+            });
+            expect(result.status).toBe(403);
+        });
+
+        it('should reject non-admin users', async () => {
+            const result = await callFunction<RevokeEnrollmentRequest>({
+                functionName: 'revokeEnrollment',
+                data: { enrollmentId: 'some-id' },
+                idToken: nonAdminUser.idToken,
+            });
+            expect([403, 500]).toContain(result.status);
+        });
+    });
+
+    describe('Validation', () => {
+        it('should reject request without enrollmentId', async () => {
+            const result = await callFunction<Record<string, never>>({
+                functionName: 'revokeEnrollment',
+                data: {},
+                idToken: adminUser.idToken,
+            });
+            expect(result.status).toBe(400);
+            expect(result.error).toContain('enrollmentId is required');
+        });
+
+        it('should return 404 for nonexistent enrollment', async () => {
+            const result = await callFunction<RevokeEnrollmentRequest>({
+                functionName: 'revokeEnrollment',
+                data: { enrollmentId: 'nonexistent-id' },
+                idToken: adminUser.idToken,
+            });
+            expect(result.status).toBe(404);
+            expect(result.error).toContain('Enrollment not found');
+        });
+
+        it('should reject revoking an already revoked enrollment', async () => {
+            await setFirestoreDoc(
+                'enrollment',
+                'already-revoked',
+                makeEnrollmentDoc(nonAdminUser.uid, { status: 'revoked' })
+            );
+
+            const result = await callFunction<RevokeEnrollmentRequest>({
+                functionName: 'revokeEnrollment',
+                data: { enrollmentId: 'already-revoked' },
+                idToken: adminUser.idToken,
+            });
+            expect(result.status).toBe(400);
+            expect(result.error).toContain('not in enrolled status');
+        });
+
+        it('should reject revoking a pending enrollment', async () => {
+            await setFirestoreDoc(
+                'enrollment',
+                'pending-enrollment',
+                makeEnrollmentDoc(nonAdminUser.uid, { status: 'pending' })
+            );
+
+            const result = await callFunction<RevokeEnrollmentRequest>({
+                functionName: 'revokeEnrollment',
+                data: { enrollmentId: 'pending-enrollment' },
+                idToken: adminUser.idToken,
+            });
+            expect(result.status).toBe(400);
+            expect(result.error).toContain('not in enrolled status');
+        });
+    });
+
+    describe('Successful revocation', () => {
+        it('should revoke an enrollment and return success', async () => {
+            await setFirestoreDoc(
+                'enrollment',
+                'revoke-me',
+                makeEnrollmentDoc(nonAdminUser.uid)
+            );
+
+            const result = await callFunction<
+                RevokeEnrollmentRequest,
+                RevokeEnrollmentResponse
+            >({
+                functionName: 'revokeEnrollment',
+                data: { enrollmentId: 'revoke-me' },
+                idToken: adminUser.idToken,
+            });
+
+            expect(result.status).toBe(200);
+            expect(result.data?.success).toBe(true);
+            expect(result.data?.refundAmount).toBe(100);
+        });
+
+        it('should mark enrollment as revoked so it no longer appears as enrolled in admin list', async () => {
+            await setFirestoreDoc(
+                'enrollment',
+                'revoke-visible',
+                makeEnrollmentDoc(nonAdminUser.uid)
+            );
+
+            // Verify it appears in admin enrollments first
+            const before = await callFunction<void, SemesterEnrollment[]>({
+                functionName: 'adminEnrollments',
+                idToken: adminUser.idToken,
+            });
+            expect(before.status).toBe(200);
+            const enrolledBefore = before.data!.find(
+                (e) => e.id === 'revoke-visible'
+            );
+            expect(enrolledBefore).toBeDefined();
+            expect(enrolledBefore!.status).toBe('enrolled');
+
+            // Revoke it
+            await callFunction<
+                RevokeEnrollmentRequest,
+                RevokeEnrollmentResponse
+            >({
+                functionName: 'revokeEnrollment',
+                data: { enrollmentId: 'revoke-visible' },
+                idToken: adminUser.idToken,
+            });
+
+            // Verify it now shows as revoked
+            const after = await callFunction<void, SemesterEnrollment[]>({
+                functionName: 'adminEnrollments',
+                idToken: adminUser.idToken,
+            });
+            expect(after.status).toBe(200);
+            const revokedAfter = after.data!.find(
+                (e) => e.id === 'revoke-visible'
+            );
+            expect(revokedAfter).toBeDefined();
+            expect(revokedAfter!.status).toBe('revoked');
+        });
+
+        it('should remove student from class roster', async () => {
+            const studentRef = new FirestoreRef('students/student-1');
+
+            await setFirestoreDoc(
+                `semesters/${SEMESTER_ID}/classes`,
+                'class-1',
+                makeClassDoc({
+                    name: 'Revoke Test Class',
+                    students: [studentRef],
+                })
+            );
+
+            await setFirestoreDoc('students', 'student-1', {
+                first_name: 'Test',
+                last_name: 'Student',
+            });
+
+            await setFirestoreDoc(
+                'enrollment',
+                'revoke-roster',
+                makeEnrollmentDoc(nonAdminUser.uid, {
+                    studentId: 'student-1',
+                    classes: [{ id: 'class-1', semesterId: SEMESTER_ID }],
+                })
+            );
+
+            const result = await callFunction<
+                RevokeEnrollmentRequest,
+                RevokeEnrollmentResponse
+            >({
+                functionName: 'revokeEnrollment',
+                data: { enrollmentId: 'revoke-roster' },
+                idToken: adminUser.idToken,
+            });
+
+            expect(result.status).toBe(200);
+            expect(result.data?.success).toBe(true);
+
+            // Verify student removed from class via roster function
+            const roster = await callFunction<
+                { classId: string; semesterId: string },
+                unknown
+            >({
+                functionName: 'roster',
+                data: { classId: 'class-1', semesterId: SEMESTER_ID },
+                idToken: adminUser.idToken,
+            });
+
+            expect(roster.status).toBe(200);
+            // Roster returns HTML; student name should not appear
+            const rosterHtml = JSON.stringify(roster.raw);
+            expect(rosterHtml).not.toContain('Test Student');
+        });
+
+        it('should handle zero-cost enrollment (no refund needed)', async () => {
+            await setFirestoreDoc(
+                'enrollment',
+                'free-enrollment',
+                makeEnrollmentDoc(nonAdminUser.uid, {
+                    finalCost: 0,
+                    transactionId: '',
+                })
+            );
+
+            const result = await callFunction<
+                RevokeEnrollmentRequest,
+                RevokeEnrollmentResponse
+            >({
+                functionName: 'revokeEnrollment',
+                data: { enrollmentId: 'free-enrollment' },
+                idToken: adminUser.idToken,
+            });
+
+            expect(result.status).toBe(200);
+            expect(result.data?.success).toBe(true);
+            expect(result.data?.refunded).toBe(false);
+            expect(result.data?.refundAmount).toBe(0);
+        });
+    });
+});

--- a/apps/functions/src/functions/index.ts
+++ b/apps/functions/src/functions/index.ts
@@ -68,3 +68,4 @@ export { updateClassGroup } from '@sol/firebase/enrollment-functions/update-clas
 export { deleteClassGroup } from '@sol/firebase/enrollment-functions/delete-class-group';
 export { getEnrollmentMessagesAdmin } from '@sol/firebase/enrollment-functions/get-enrollment-messages-admin';
 export { updateEnrollmentMessages } from '@sol/firebase/enrollment-functions/update-enrollment-messages';
+export { revokeEnrollment } from '@sol/firebase/enrollment-functions/revoke-enrollment';

--- a/libs/angular/admin/enrollments/src/lib/components/confirm-revoke-dialog.component.ts
+++ b/libs/angular/admin/enrollments/src/lib/components/confirm-revoke-dialog.component.ts
@@ -1,0 +1,64 @@
+import { Component, inject } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { CurrencyPipe } from '@angular/common';
+
+export interface ConfirmRevokeDialogData {
+    studentName: string;
+    finalCost: number;
+}
+
+@Component({
+    selector: 'sol-confirm-revoke-dialog',
+    standalone: true,
+    imports: [MatButtonModule, CurrencyPipe],
+    template: `
+        <div class="dialog-content">
+            <h2>Revoke Enrollment</h2>
+            <p>
+                Are you sure you want to revoke the enrollment for
+                <strong>{{ data.studentName }}</strong
+                >?
+            </p>
+            @if (data.finalCost > 0) {
+                <p>
+                    A refund of <strong>{{ data.finalCost | currency }}</strong>
+                    will be issued.
+                </p>
+            }
+            <p>The student will be removed from all enrolled classes.</p>
+            <div class="dialog-actions">
+                <button mat-stroked-button (click)="dialogRef.close(false)">
+                    Cancel
+                </button>
+                <button
+                    mat-raised-button
+                    color="warn"
+                    (click)="dialogRef.close(true)"
+                >
+                    Revoke & Refund
+                </button>
+            </div>
+        </div>
+    `,
+    styles: [
+        `
+            .dialog-content {
+                padding: 1.5rem;
+            }
+            h2 {
+                margin: 0 0 1rem;
+            }
+            .dialog-actions {
+                display: flex;
+                justify-content: flex-end;
+                gap: 0.5rem;
+                margin-top: 1.5rem;
+            }
+        `,
+    ],
+})
+export class ConfirmRevokeDialogComponent {
+    readonly data = inject<ConfirmRevokeDialogData>(DIALOG_DATA);
+    readonly dialogRef = inject(DialogRef<boolean>);
+}

--- a/libs/angular/admin/enrollments/src/lib/components/enrollments.component.html
+++ b/libs/angular/admin/enrollments/src/lib/components/enrollments.component.html
@@ -1,5 +1,4 @@
 <h1>Enrollments</h1>
-<!-- div with button flex aligned to right -->
 <div style="display: flex; justify-content: flex-end; margin-bottom: 1rem">
     <button
         type="button"
@@ -36,6 +35,9 @@
             <th pSortableColumn="finalCost">
                 Final Cost <p-sortIcon field="finalCost"></p-sortIcon>
             </th>
+            <th pSortableColumn="status">
+                Status <p-sortIcon field="status"></p-sortIcon>
+            </th>
             @for (
                 discount of longestDiscounts$ | async;
                 track discount;
@@ -54,13 +56,22 @@
                     ></p-sortIcon>
                 </th>
             }
+            <th>Actions</th>
         </tr>
     </ng-template>
     <ng-template pTemplate="body" let-enrollment>
-        <tr>
+        <tr [style.opacity]="enrollment.status === 'revoked' ? '0.6' : '1'">
             <td>{{ enrollment.studentName }}</td>
             <td>{{ enrollment.date | date }}</td>
             <td>{{ enrollment.finalCost | currency }}</td>
+            <td>
+                <span
+                    [style.color]="enrollment.status === 'revoked' ? 'var(--sol-error, #b00020)' : 'inherit'"
+                    [style.font-weight]="enrollment.status === 'revoked' ? '500' : 'normal'"
+                >
+                    {{ enrollment.status === 'revoked' ? 'Revoked' : 'Enrolled' }}
+                </span>
+            </td>
             @for (
                 discount of longestDiscounts$ | async;
                 track discount;
@@ -73,6 +84,18 @@
                     }}
                 </td>
             }
+            <td>
+                @if (enrollment.status !== 'revoked') {
+                    <button
+                        mat-stroked-button
+                        color="warn"
+                        [disabled]="revoking() === enrollment.id"
+                        (click)="confirmRevoke(enrollment)"
+                    >
+                        {{ revoking() === enrollment.id ? 'Revoking...' : 'Revoke & Refund' }}
+                    </button>
+                }
+            </td>
         </tr>
     </ng-template>
 </p-table>

--- a/libs/angular/admin/enrollments/src/lib/components/enrollments.component.ts
+++ b/libs/angular/admin/enrollments/src/lib/components/enrollments.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { FirebaseFunctionsService } from '@sol/firebase/functions-api';
-import { Observable, map, shareReplay } from 'rxjs';
+import { Observable, map, shareReplay, firstValueFrom, Subject, switchMap, startWith } from 'rxjs';
 import { AsyncPipe, CurrencyPipe, DatePipe } from '@angular/common';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { TableModule } from 'primeng/table';
@@ -8,6 +8,13 @@ import { SemesterEnrollment } from '@sol/classes/domain';
 import { ButtonModule } from 'primeng/button';
 import { RippleModule } from 'primeng/ripple';
 import { RequestedOperatorsUtility } from '@sol/angular/request';
+import { MatButtonModule } from '@angular/material/button';
+import { Dialog } from '@angular/cdk/dialog';
+import {
+    ConfirmRevokeDialogComponent,
+    ConfirmRevokeDialogData,
+} from './confirm-revoke-dialog.component';
+import { MountainSolApiService } from '@sol/angular/firebase/api';
 
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -19,32 +26,45 @@ import { RequestedOperatorsUtility } from '@sol/angular/request';
         ButtonModule,
         RippleModule,
         DatePipe,
+        MatButtonModule,
     ],
     templateUrl: './enrollments.component.html',
 })
 export class EnrollmentsComponent {
-    readonly enrollments$ = inject(FirebaseFunctionsService)
-        .call<Array<SemesterEnrollment>>('adminEnrollments')
-        .pipe(
-            RequestedOperatorsUtility.ignoreAllStatesButLoaded(),
-            map((enrollments) => {
-                return enrollments
-                    .concat()
-                    .sort((a, b) => b.timestamp._seconds - a.timestamp._seconds)
-                    .map((enrollment) => ({
-                        ...enrollment,
-                        date: enrollment.timestamp._seconds * 1000,
-                        ...enrollment.discounts
-                            .map((discount, i) => ({
-                                [`discount${i}_description`]:
-                                    discount.description,
-                                [`discount${i}_amount`]: discount.amount,
-                            }))
-                            .reduce((acc, cur) => ({ ...acc, ...cur }), {}),
-                    }));
-            }),
-            shareReplay()
-        );
+    readonly #functions = inject(FirebaseFunctionsService);
+    readonly #dialog = inject(Dialog);
+    readonly #api = inject(MountainSolApiService);
+    readonly #refreshTrigger = new Subject<void>();
+
+    readonly revoking = signal<string | null>(null);
+
+    readonly enrollments$ = this.#refreshTrigger.pipe(
+        startWith(undefined),
+        switchMap(() =>
+            this.#functions
+                .call<Array<SemesterEnrollment>>('adminEnrollments')
+                .pipe(
+                    RequestedOperatorsUtility.ignoreAllStatesButLoaded(),
+                )
+        ),
+        map((enrollments) => {
+            return enrollments
+                .concat()
+                .sort((a, b) => b.timestamp._seconds - a.timestamp._seconds)
+                .map((enrollment) => ({
+                    ...enrollment,
+                    date: enrollment.timestamp._seconds * 1000,
+                    ...enrollment.discounts
+                        .map((discount, i) => ({
+                            [`discount${i}_description`]:
+                                discount.description,
+                            [`discount${i}_amount`]: discount.amount,
+                        }))
+                        .reduce((acc, cur) => ({ ...acc, ...cur }), {}),
+                }));
+        }),
+        shareReplay()
+    );
 
     readonly longestDiscounts$: Observable<Array<number>> =
         this.enrollments$.pipe(
@@ -65,6 +85,7 @@ export class EnrollmentsComponent {
             { field: 'studentName', header: 'Student Name' },
             { field: 'date', header: 'Date' },
             { field: 'finalCost', header: 'Final Cost' },
+            { field: 'status', header: 'Status' },
             ...longest.map((_, i) => ({
                 field: `discount${i}_description`,
                 header: `Discount ${i + 1} Name`,
@@ -75,4 +96,30 @@ export class EnrollmentsComponent {
             })),
         ])
     );
+
+    async confirmRevoke(enrollment: SemesterEnrollment & { date: number }) {
+        const dialogRef = this.#dialog.open<boolean, ConfirmRevokeDialogData>(
+            ConfirmRevokeDialogComponent,
+            {
+                width: '400px',
+                data: {
+                    studentName: enrollment.studentName,
+                    finalCost: enrollment.finalCost,
+                },
+            }
+        );
+
+        const result = await firstValueFrom(dialogRef.closed);
+        if (result) {
+            this.revoking.set(enrollment.id);
+            try {
+                await firstValueFrom(
+                    this.#api.revokeEnrollment({ enrollmentId: enrollment.id })
+                );
+                this.#refreshTrigger.next();
+            } finally {
+                this.revoking.set(null);
+            }
+        }
+    }
 }

--- a/libs/angular/firebase/api/src/lib/services/mountain-sol-api.service.ts
+++ b/libs/angular/firebase/api/src/lib/services/mountain-sol-api.service.ts
@@ -46,6 +46,8 @@ import type {
     UpdateClassGroupResponse,
     DeleteClassGroupRequest,
     DeleteClassGroupResponse,
+    RevokeEnrollmentRequest,
+    RevokeEnrollmentResponse,
 } from '@sol/ts/firebase/api-types';
 
 // Re-export types for consumers
@@ -94,6 +96,8 @@ export type {
     UpdateClassGroupResponse,
     DeleteClassGroupRequest,
     DeleteClassGroupResponse,
+    RevokeEnrollmentRequest,
+    RevokeEnrollmentResponse,
 };
 
 /**
@@ -278,4 +282,13 @@ export class MountainSolApiService {
         DeleteClassGroupRequest,
         DeleteClassGroupResponse
     >(this.#functions, 'deleteClassGroup');
+
+    // =========================================================================
+    // Enrollment Management
+    // =========================================================================
+
+    readonly revokeEnrollment = declareFunction<
+        RevokeEnrollmentRequest,
+        RevokeEnrollmentResponse
+    >(this.#functions, 'revokeEnrollment');
 }

--- a/libs/firebase/braintree/src/lib/braintree.utility.ts
+++ b/libs/firebase/braintree/src/lib/braintree.utility.ts
@@ -125,6 +125,17 @@ export class Braintree {
         return await this.gateway.transaction.sale(transactionRequest);
     }
 
+    public async refund(transactionId: string) {
+        if (this.isEmulator) {
+            return Braintree.EMULATOR_MOCK_TRANSACTION;
+        }
+        try {
+            return await this.gateway.transaction.refund(transactionId);
+        } catch {
+            return await this.gateway.transaction.void(transactionId);
+        }
+    }
+
     public async getAnonymousClientToken() {
         if (this.isEmulator) {
             return 'emulator-mock-anonymous-client-token';

--- a/libs/firebase/classes/class-enrollment-repository/src/lib/models/db/class-enrollment.dbo.ts
+++ b/libs/firebase/classes/class-enrollment-repository/src/lib/models/db/class-enrollment.dbo.ts
@@ -15,7 +15,7 @@ export type ClassEnrollmentDbo = {
         description: string;
     }>;
     transactionId?: string;
-    status: 'pending' | 'enrolled' | 'failed';
+    status: 'pending' | 'enrolled' | 'failed' | 'revoked';
     failures?: Array<string>;
     isSignedUpForSolsticeEmails?: boolean;
     releaseSignatures?: Array<{

--- a/libs/firebase/classes/class-enrollment-repository/src/lib/services/class-enrollment-repository.ts
+++ b/libs/firebase/classes/class-enrollment-repository/src/lib/services/class-enrollment-repository.ts
@@ -66,12 +66,22 @@ export class ClassEnrollmentRepository {
         );
     }
 
+    static async updateStatus(
+        enrollmentId: string,
+        status: ClassEnrollmentDbo['status']
+    ): Promise<void> {
+        await this.database
+            .collection('enrollment')
+            .doc(enrollmentId)
+            .update({ status });
+    }
+
     static async getCurrentSemesterEnrollments(): Promise<
         Array<SemesterEnrollment>
     > {
         const snapshot = await this.database
             .collection('enrollment')
-            .where('status', '==', 'enrolled')
+            .where('status', 'in', ['enrolled', 'revoked'])
             .get();
         return await Promise.all(
             snapshot.docs.map(async (doc) => {
@@ -86,6 +96,7 @@ export class ClassEnrollmentRepository {
                     transactionId: dbo.transactionId,
                     timestamp: dbo.timestamp,
                     discounts: dbo.discounts,
+                    status: dbo.status,
                     enrollmentType: dbo.enrollmentType,
                     originalEnrollmentId: dbo.originalEnrollmentId,
                     additionalOptionIdsByClassId:

--- a/libs/firebase/classes/class-repository/src/lib/class.repository.ts
+++ b/libs/firebase/classes/class-repository/src/lib/class.repository.ts
@@ -155,6 +155,52 @@ export class ClassRepository {
         return domain;
     }
 
+    async removeStudentFromClass(
+        studentId: string,
+        classId: string,
+        additionalOptionIds: Array<string>
+    ): Promise<void> {
+        const classRef = await DatabaseUtility.getDocumentRef(
+            `${await this.getClassesPath()}/${classId}`
+        );
+        const studentRef = await DatabaseUtility.getDocumentRef(
+            `students/${studentId}`
+        );
+
+        const classData = (await classRef.get()).data() as ClassDbo | undefined;
+        const enrolledStudents = classData?.students ?? [];
+
+        const updatedStudents = enrolledStudents.filter(
+            (ref) => ref.id !== studentRef.id
+        );
+
+        if (updatedStudents.length !== enrolledStudents.length) {
+            await classRef.update({ students: updatedStudents });
+        }
+
+        const additionalOptionsCollection =
+            classRef.collection('additional_options');
+
+        for (const optionId of additionalOptionIds) {
+            const optionRef = additionalOptionsCollection.doc(optionId);
+            const optionDoc = await optionRef.get();
+
+            if (optionDoc.exists) {
+                const optionData = optionDoc.data();
+                const currentStudents = optionData?.students ?? [];
+                const updatedOptionStudents = currentStudents.filter(
+                    (ref: DocumentReference) => ref.id !== studentRef.id
+                );
+
+                if (updatedOptionStudents.length !== currentStudents.length) {
+                    await optionRef.update({
+                        students: updatedOptionStudents,
+                    });
+                }
+            }
+        }
+    }
+
     async addStudentToClass(
         studentId: string,
         classId: string,

--- a/libs/firebase/enrollment-functions/revoke-enrollment/package.json
+++ b/libs/firebase/enrollment-functions/revoke-enrollment/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "@sol/firebase/enrollment-functions/revoke-enrollment",
+    "version": "0.0.1",
+    "dependencies": {},
+    "private": true
+}

--- a/libs/firebase/enrollment-functions/revoke-enrollment/project.json
+++ b/libs/firebase/enrollment-functions/revoke-enrollment/project.json
@@ -1,0 +1,9 @@
+{
+    "name": "firebase-enrollment-functions-revoke-enrollment",
+    "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "libs/firebase/enrollment-functions/revoke-enrollment/src",
+    "projectType": "library",
+    "tags": [],
+    "// targets": "to see all targets run: nx show project firebase-enrollment-functions-revoke-enrollment --web",
+    "targets": {}
+}

--- a/libs/firebase/enrollment-functions/revoke-enrollment/src/index.ts
+++ b/libs/firebase/enrollment-functions/revoke-enrollment/src/index.ts
@@ -1,0 +1,1 @@
+export { revokeEnrollment } from './lib/revoke-enrollment';

--- a/libs/firebase/enrollment-functions/revoke-enrollment/src/lib/revoke-enrollment.ts
+++ b/libs/firebase/enrollment-functions/revoke-enrollment/src/lib/revoke-enrollment.ts
@@ -1,0 +1,78 @@
+import { Functions, Role } from '@sol/firebase/functions';
+import { Braintree } from '@sol/payments/braintree';
+import { ClassEnrollmentRepository } from '@sol/classes/enrollment/repository';
+import { Semester } from '@sol/firebase/classes/semester';
+import type {
+    RevokeEnrollmentRequest,
+    RevokeEnrollmentResponse,
+} from '@sol/ts/firebase/api-types';
+
+export const revokeEnrollment = Functions.endpoint
+    .restrictedToRoles(Role.Admin)
+    .usingSecrets(...Braintree.SECRET_NAMES)
+    .usingStrings(...Braintree.STRING_NAMES)
+    .handle<RevokeEnrollmentRequest>(async (request, response, secrets, strings) => {
+        const { enrollmentId } = request.body.data;
+
+        if (!enrollmentId) {
+            response.status(400).send({ error: 'enrollmentId is required' });
+            return;
+        }
+
+        const enrollment = await ClassEnrollmentRepository.getById(enrollmentId);
+
+        if (!enrollment) {
+            response.status(404).send({ error: 'Enrollment not found' });
+            return;
+        }
+
+        if (enrollment.status !== 'enrolled') {
+            response.status(400).send({ error: 'Enrollment is not in enrolled status' });
+            return;
+        }
+
+        let refunded = false;
+        const refundAmount = enrollment.finalCost;
+
+        if (enrollment.transactionId && enrollment.finalCost > 0) {
+            const braintree = new Braintree(secrets, strings);
+            const result = await braintree.refund(enrollment.transactionId);
+
+            if (!result.success) {
+                response.status(500).send({
+                    error: 'Refund failed',
+                    details: result.errors?.deepErrors().map((e) => e.message) ?? [],
+                });
+                return;
+            }
+
+            refunded = true;
+        }
+
+        const classes = 'classes' in enrollment
+            ? enrollment.classes
+            : (enrollment as { classIds: string[] }).classIds.map((id) => ({ id, semesterId: '' }));
+
+        if (enrollment.studentId) {
+            await Promise.allSettled(
+                classes
+                    .filter((c) => c.semesterId)
+                    .map((c) =>
+                        Semester.of(c.semesterId).classes.removeStudentFromClass(
+                            enrollment.studentId!,
+                            c.id,
+                            enrollment.additionalOptionIdsByClassId[c.id] ?? []
+                        )
+                    )
+            );
+        }
+
+        await ClassEnrollmentRepository.updateStatus(enrollmentId, 'revoked');
+
+        const result: RevokeEnrollmentResponse = {
+            success: true,
+            refunded,
+            refundAmount,
+        };
+        response.send(result);
+    });

--- a/libs/firebase/enrollment-functions/revoke-enrollment/tsconfig.json
+++ b/libs/firebase/enrollment-functions/revoke-enrollment/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "es2022"
+    },
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        }
+    ]
+}

--- a/libs/firebase/enrollment-functions/revoke-enrollment/tsconfig.lib.json
+++ b/libs/firebase/enrollment-functions/revoke-enrollment/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../../dist/out-tsc",
+        "declaration": true,
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"]
+}

--- a/libs/ts/classes/classes-domain/src/lib/models/semester-enrollment.ts
+++ b/libs/ts/classes/classes-domain/src/lib/models/semester-enrollment.ts
@@ -6,6 +6,7 @@ export type SemesterEnrollment = {
     transactionId: string;
     timestamp: { _seconds: number };
     discounts: Array<{ amount: number; description: string }>;
+    status?: 'enrolled' | 'revoked';
     enrollmentType?: 'standard' | 'addendum';
     originalEnrollmentId?: string;
     additionalOptionIdsByClassId?: Record<string, Array<string>>;

--- a/libs/ts/firebase/api-types/src/index.ts
+++ b/libs/ts/firebase/api-types/src/index.ts
@@ -58,6 +58,12 @@ export type {
     GetActiveMultiClassDiscountResponse,
 } from './lib/discount.types';
 
+// Enrollment Management
+export type {
+    RevokeEnrollmentRequest,
+    RevokeEnrollmentResponse,
+} from './lib/enrollment.types';
+
 // Enrollment Messages
 export type {
     EnrollmentMessageSeverity,

--- a/libs/ts/firebase/api-types/src/lib/enrollment.types.ts
+++ b/libs/ts/firebase/api-types/src/lib/enrollment.types.ts
@@ -1,0 +1,9 @@
+export type RevokeEnrollmentRequest = {
+    enrollmentId: string;
+};
+
+export type RevokeEnrollmentResponse = {
+    success: boolean;
+    refunded: boolean;
+    refundAmount: number;
+};

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -337,6 +337,9 @@
             "@sol/firebase/enrollment-functions/delete-discount": [
                 "libs/firebase/enrollment-functions/delete-discount/src/index.ts"
             ],
+            "@sol/firebase/enrollment-functions/revoke-enrollment": [
+                "libs/firebase/enrollment-functions/revoke-enrollment/src/index.ts"
+            ],
             "@sol/firebase/enrollment-functions/get-enrollment-messages": [
                 "libs/firebase/enrollment-functions/get-enrollment-messages/src/index.ts"
             ],


### PR DESCRIPTION
## Summary
- Adds a **Revoke & Refund** action to the admin enrollments table so staff can withdraw students and issue refunds
- New `revokeEnrollment` Firebase function: validates enrollment, issues Braintree refund (or void for unsettled transactions), removes student from all enrolled classes, and marks enrollment as revoked
- Admin enrollments view now shows enrollment status (Enrolled/Revoked) and action buttons with a confirmation dialog

## What changed

**Backend:**
- `Braintree.refund()` — tries refund first, falls back to void
- `ClassRepository.removeStudentFromClass()` — inverse of `addStudentToClass`
- `ClassEnrollmentRepository.updateStatus()` — updates enrollment status
- Admin enrollments query now includes revoked enrollments
- New `revokeEnrollment` function library (admin-only)

**Frontend:**
- `MountainSolApiService.revokeEnrollment()` typed API call
- Status column + Revoke & Refund button in admin enrollments table
- Confirmation dialog before revoking (shows refund amount)

## Test plan
- [ ] Build passes (`nx build functions`, `nx build enrollment-portal`)
- [ ] Navigate to admin enrollments — verify Status column and Revoke & Refund button appear
- [ ] Click Revoke & Refund — verify confirmation dialog shows student name and refund amount
- [ ] Cancel dialog — verify no action taken
- [ ] Confirm revoke — verify enrollment status changes to Revoked, button disappears, row dims
- [ ] Verify student is removed from class roster after revocation
- [ ] Integration test to be added in follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)