### PR TITLE
fix: revoke enrollment refund handling and UI polish

### DIFF
--- a/libs/angular/admin/enrollments/src/lib/components/confirm-revoke-dialog.component.ts
+++ b/libs/angular/admin/enrollments/src/lib/components/confirm-revoke-dialog.component.ts
@@ -43,6 +43,12 @@ export interface ConfirmRevokeDialogData {
     `,
     styles: [
         `
+            :host {
+                display: block;
+                background: white;
+                border-radius: 8px;
+                box-shadow: 0 11px 15px -7px rgba(0,0,0,.2), 0 24px 38px 3px rgba(0,0,0,.14), 0 9px 46px 8px rgba(0,0,0,.12);
+            }
             .dialog-content {
                 padding: 1.5rem;
             }

--- a/libs/angular/admin/enrollments/src/lib/components/enrollments.component.html
+++ b/libs/angular/admin/enrollments/src/lib/components/enrollments.component.html
@@ -1,4 +1,10 @@
 <h1>Enrollments</h1>
+@if (revokeError()) {
+    <div style="background: #fdecea; color: #b00020; padding: 0.75rem 1rem; border-radius: 4px; margin-bottom: 1rem; display: flex; justify-content: space-between; align-items: center">
+        <span>{{ revokeError() }}</span>
+        <button mat-button style="color: #b00020" (click)="revokeError.set(null)">Dismiss</button>
+    </div>
+}
 <div style="display: flex; justify-content: flex-end; margin-bottom: 1rem">
     <button
         type="button"

--- a/libs/angular/admin/enrollments/src/lib/components/enrollments.component.ts
+++ b/libs/angular/admin/enrollments/src/lib/components/enrollments.component.ts
@@ -37,6 +37,7 @@ export class EnrollmentsComponent {
     readonly #refreshTrigger = new Subject<void>();
 
     readonly revoking = signal<string | null>(null);
+    readonly revokeError = signal<string | null>(null);
 
     readonly enrollments$ = this.#refreshTrigger.pipe(
         startWith(undefined),
@@ -109,14 +110,19 @@ export class EnrollmentsComponent {
             }
         );
 
-        const result = await firstValueFrom(dialogRef.closed);
-        if (result) {
+        const confirmed = await firstValueFrom(dialogRef.closed);
+        if (confirmed) {
             this.revoking.set(enrollment.id);
+            this.revokeError.set(null);
             try {
                 await firstValueFrom(
                     this.#api.revokeEnrollment({ enrollmentId: enrollment.id })
                 );
                 this.#refreshTrigger.next();
+            } catch (e: unknown) {
+                const message =
+                    e instanceof Error ? e.message : 'Revocation failed. Please try again.';
+                this.revokeError.set(message);
             } finally {
                 this.revoking.set(null);
             }

--- a/libs/firebase/braintree/src/lib/braintree.utility.ts
+++ b/libs/firebase/braintree/src/lib/braintree.utility.ts
@@ -129,11 +129,11 @@ export class Braintree {
         if (this.isEmulator) {
             return Braintree.EMULATOR_MOCK_TRANSACTION;
         }
-        try {
-            return await this.gateway.transaction.refund(transactionId);
-        } catch {
-            return await this.gateway.transaction.void(transactionId);
+        const voidResult = await this.gateway.transaction.void(transactionId);
+        if (voidResult.success) {
+            return voidResult;
         }
+        return await this.gateway.transaction.refund(transactionId);
     }
 
     public async getAnonymousClientToken() {


### PR DESCRIPTION
## Summary
- **Fix Braintree refund logic**: try void first (for unsettled transactions), fall back to refund (for settled). The previous try/catch didn't work because the Braintree SDK returns `{ success: false }` instead of throwing.
- **Add error banner**: when revocation fails, show a dismissible error message on the enrollments page instead of silently failing
- **Fix dialog styling**: add white background and elevation to the CDK Dialog confirmation panel (was rendering transparent)

## Test plan
- [ ] Revoke a recently-created enrollment (unsettled transaction) — should void successfully
- [ ] Revoke an older enrollment (settled transaction) — should refund successfully
- [ ] If revocation fails for any reason, error banner appears with message
- [ ] Dismiss button clears the error
- [ ] Dialog renders with white background and elevation shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)