### PR TITLE
fix: improve revoke error handling for unsettled transactions

### DIFF
--- a/libs/angular/admin/enrollments/src/lib/components/enrollments.component.ts
+++ b/libs/angular/admin/enrollments/src/lib/components/enrollments.component.ts
@@ -130,10 +130,10 @@ export class EnrollmentsComponent {
                     })
                 );
                 this.#refreshTrigger.next();
-            } catch (e: unknown) {
-                const message =
-                    e instanceof Error ? e.message : 'Revocation failed. Please try again.';
-                this.revokeError.set(message);
+            } catch {
+                this.revokeError.set(
+                    'Revocation failed. The refund may not have been processed — check Braintree before retrying.'
+                );
             } finally {
                 this.revoking.set(null);
             }

--- a/libs/firebase/enrollment-functions/revoke-enrollment/src/lib/revoke-enrollment.ts
+++ b/libs/firebase/enrollment-functions/revoke-enrollment/src/lib/revoke-enrollment.ts
@@ -51,9 +51,14 @@ export const revokeEnrollment = Functions.endpoint
                 : await braintree.refund(enrollment.transactionId, effectiveRefundAmount);
 
             if (!result.success) {
-                response.status(500).send({
-                    error: 'Refund failed',
-                    details: result.errors?.deepErrors().map((e) => e.message) ?? [],
+                const details = result.errors?.deepErrors().map((e) => e.message) ?? [];
+                const isSettlementIssue = details.some((d) =>
+                    d.toLowerCase().includes('settled')
+                );
+                response.status(400).send({
+                    error: isSettlementIssue
+                        ? 'Transaction has not settled yet. Partial refunds require a settled transaction. Please try again later or use a full revocation (void).'
+                        : 'Refund failed: ' + details.join('; '),
                 });
                 return;
             }


### PR DESCRIPTION
## Summary
- Fix UI showing "no elements in sequence" when revocation fails — `FirebaseFunctionsService` swallows HTTP errors, so show a clear actionable message instead
- Detect unsettled transaction errors from Braintree and return a specific message: "Transaction has not settled yet. Partial refunds require a settled transaction."
- Change refund failure status from 500 to 400

## Test plan
- [ ] Attempt partial revoke on same-day enrollment (unsettled) — should show clear error about settlement
- [ ] Attempt partial revoke on settled transaction — should succeed
- [ ] Error banner is dismissible

🤖 Generated with [Claude Code](https://claude.com/claude-code)