### PR TITLE
fix: log skips, failures, and recipients in enrollment email trigger

### DIFF
--- a/libs/firebase/enrollment-functions/create-enrollment-email/src/lib/create-enrollment-email.ts
+++ b/libs/firebase/enrollment-functions/create-enrollment-email/src/lib/create-enrollment-email.ts
@@ -10,16 +10,35 @@ import { ClassEnrollmentRepository } from '@sol/classes/enrollment/repository';
 export const createEnrollmentEmail = onDocumentCreated(
     'enrollment/{enrollmentId}',
     async (event) => {
+        const enrollmentId = event.params.enrollmentId;
         const enrollmentRecord =
             event.data && (event.data.data() as ClassEnrollmentDbo);
 
+        if (!enrollmentRecord) {
+            console.warn(
+                `[createEnrollmentEmail] Skipped: no enrollment data for ${enrollmentId}`
+            );
+            return;
+        }
+
+        const hasPaymentOrFree =
+            !!enrollmentRecord.transactionId ||
+            enrollmentRecord.finalCost === 0;
+        const hasClasses =
+            'classIds' in enrollmentRecord || 'classes' in enrollmentRecord;
+
         if (
-            enrollmentRecord &&
-            enrollmentRecord.status === 'enrolled' &&
-            (!!enrollmentRecord.transactionId ||
-                enrollmentRecord.finalCost === 0) &&
-            ('classIds' in enrollmentRecord || 'classes' in enrollmentRecord)
+            enrollmentRecord.status !== 'enrolled' ||
+            !hasPaymentOrFree ||
+            !hasClasses
         ) {
+            console.info(
+                `[createEnrollmentEmail] Skipped ${enrollmentId}: status=${enrollmentRecord.status}, hasPaymentOrFree=${hasPaymentOrFree}, hasClasses=${hasClasses}`
+            );
+            return;
+        }
+
+        try {
             const semesters = await _getSemestersAvailableToEnroll();
             const semesterNamesById = semesters.reduce(
                 (acc, s) => ({ ...acc, [s.id]: s.name }),
@@ -86,6 +105,14 @@ export const createEnrollmentEmail = onDocumentCreated(
                 enrollmentRecord.finalCost - (classesCost - totalDiscounts);
             const user = await AuthUtility.getUser(enrollmentRecord.userId);
 
+            const recipient = user.email ?? enrollmentRecord.contactEmail;
+            if (!recipient) {
+                console.error(
+                    `[createEnrollmentEmail] Cannot send for ${enrollmentId}: no recipient email (userId=${enrollmentRecord.userId}, no contactEmail on record)`
+                );
+                return;
+            }
+
             const isAddendum = enrollmentRecord.enrollmentType === 'addendum';
 
             const { html, text } = generateEmailContent(
@@ -96,14 +123,16 @@ export const createEnrollmentEmail = onDocumentCreated(
                 isAddendum
             );
 
-            await DatabaseUtility.getDatabase()
+            const subject = isAddendum
+                ? `Enrollment addendum for ${enrollmentRecord.studentName}`
+                : `Class confirmation for ${enrollmentRecord.studentName}`;
+
+            const mailDoc = await DatabaseUtility.getDatabase()
                 .collection('mail')
                 .add({
-                    to: user.email ?? enrollmentRecord.contactEmail,
+                    to: recipient,
                     message: {
-                        subject: isAddendum
-                            ? `Enrollment addendum for ${enrollmentRecord.studentName}`
-                            : `Class confirmation for ${enrollmentRecord.studentName}`,
+                        subject,
                         from: `Mountain SOL School <info@mountainsol.org>`,
                         replyTo: `Mountain SOL School <info@mountainsol.org>`,
                         messageId: `<${enrollmentRecord.transactionId}.${Date.now()}@mountainsol.org>`,
@@ -111,6 +140,16 @@ export const createEnrollmentEmail = onDocumentCreated(
                         text,
                     },
                 });
+
+            console.info(
+                `[createEnrollmentEmail] Queued mail/${mailDoc.id} for enrollment ${enrollmentId} to ${recipient}`
+            );
+        } catch (error) {
+            console.error(
+                `[createEnrollmentEmail] Failed for enrollment ${enrollmentId}:`,
+                error
+            );
+            throw error;
         }
     }
 );


### PR DESCRIPTION
## Summary

Parents have reported not receiving the existing class-confirmation email. The trigger at `libs/firebase/enrollment-functions/create-enrollment-email/src/lib/create-enrollment-email.ts` was fire-and-forget with no logging, so we currently have no visibility into where the gap is — the trigger itself, the missing-data skip paths, or the downstream Trigger Email extension.

This PR is purely diagnostic. It adds enough logging to tell those apart, plus one defensive guard.

- **try/catch with `console.error` + rethrow.** Failures (e.g. `_getClasses` throwing, `AuthUtility.getUser` failing) now surface in Cloud Logging instead of silently terminating the trigger.
- **Skip-reason logs.** Each early return now logs `status`, `hasPaymentOrFree`, and `hasClasses` so we can see when an enrollment didn't qualify and why.
- **Explicit missing-recipient handling.** Previously, if both `user.email` and `enrollmentRecord.contactEmail` were missing, we wrote `to: undefined` and confused the Trigger Email extension. Now logs an error and skips.
- **Success log.** Logs `Queued mail/<docId> for enrollment <id> to <email>` so we can correlate the trigger's view of the world with `mail/*` docs and the extension's processing.

No behavior change on the happy path.

## Test plan

- [ ] Merge & deploy
- [ ] Trigger an enrollment in dev, confirm `Queued mail/<docId>` appears in logs
- [ ] Cloud Logging filter `function_name="createEnrollmentEmail"`: check for recent `Queued`, `Skipped`, or `Failed` lines around enrollments parents reported as missing email
- [ ] Cross-reference any `Queued` log with the matching `mail/<docId>` doc and the Trigger Email extension's logs for that doc to localize where the gap is

🤖 Generated with [Claude Code](https://claude.com/claude-code)