### PR TITLE
fix: improve email deliverability headers in transactional sends

### DIFF
--- a/libs/firebase/enrollment-functions/create-enrollment-email/src/lib/create-enrollment-email.ts
+++ b/libs/firebase/enrollment-functions/create-enrollment-email/src/lib/create-enrollment-email.ts
@@ -147,6 +147,9 @@ export const createEnrollmentEmail = onDocumentCreated(
                 ? `Enrollment addendum for ${enrollmentRecord.studentName}`
                 : `Class confirmation for ${enrollmentRecord.studentName}`;
 
+            const messageIdLocalPart =
+                enrollmentRecord.transactionId ?? `enrollment-${enrollmentId}`;
+
             const mailDoc = await DatabaseUtility.getDatabase()
                 .collection('mail')
                 .add({
@@ -155,7 +158,10 @@ export const createEnrollmentEmail = onDocumentCreated(
                         subject,
                         from: `Mountain SOL School <info@mountainsol.org>`,
                         replyTo: `Mountain SOL School <info@mountainsol.org>`,
-                        messageId: `<${enrollmentRecord.transactionId}.${Date.now()}@mountainsol.org>`,
+                        messageId: `<${messageIdLocalPart}.${Date.now()}@mountainsol.org>`,
+                        headers: {
+                            'Auto-Submitted': 'auto-generated',
+                        },
                         html,
                         text,
                     },

--- a/libs/firebase/payments/src/lib/payment-handler.ts
+++ b/libs/firebase/payments/src/lib/payment-handler.ts
@@ -14,9 +14,7 @@ interface TransactionResult {
     errors?: string[];
 }
 
-export abstract class PaymentHandler<
-    TRequest extends BasePaymentRequest,
-> {
+export abstract class PaymentHandler<TRequest extends BasePaymentRequest> {
     constructor(protected readonly braintree: Braintree) {}
 
     protected abstract getFactory(): PaymentFactory<TRequest>;
@@ -99,10 +97,9 @@ export abstract class PaymentHandler<
                 };
             }
 
-            const errorMessages =
-                result.errors?.deepErrors().map((e) => e.message) ?? [
-                    'Transaction failed',
-                ];
+            const errorMessages = result.errors
+                ?.deepErrors()
+                .map((e) => e.message) ?? ['Transaction failed'];
             return {
                 success: false,
                 errors: errorMessages,
@@ -111,7 +108,9 @@ export abstract class PaymentHandler<
             console.error('Payment transaction error:', error);
             return {
                 success: false,
-                errors: ['An unexpected error occurred during payment processing'],
+                errors: [
+                    'An unexpected error occurred during payment processing',
+                ],
             };
         }
     }
@@ -135,6 +134,8 @@ export abstract class PaymentHandler<
         });
         const subject = strategy.getSubject();
 
+        const messageIdLocalPart = transactionId || `payment-${Date.now()}`;
+
         await DatabaseUtility.getDatabase()
             .collection('mail')
             .add({
@@ -143,7 +144,10 @@ export abstract class PaymentHandler<
                     subject,
                     from: 'Mountain SOL School <info@mountainsol.org>',
                     replyTo: 'Mountain SOL School <info@mountainsol.org>',
-                    messageId: `<${transactionId}.${Date.now()}@mountainsol.org>`,
+                    messageId: `<${messageIdLocalPart}.${Date.now()}@mountainsol.org>`,
+                    headers: {
+                        'Auto-Submitted': 'auto-generated',
+                    },
                     html,
                     text,
                 },


### PR DESCRIPTION
## Summary

Two small fixes to reduce the chance of class-confirmation emails being marked as spam.

### 1. Always produce a well-formed `Message-ID`

The trigger guard in `create-enrollment-email.ts` allows an email through when `finalCost === 0` even if `transactionId` is missing — the legitimate "free enrollment" case. But the `Message-ID` was being built as `<\${transactionId}.\${Date.now()}@mountainsol.org>`, which serialized to `<undefined.1234567890@mountainsol.org>` — an invalid RFC 5322 Message-ID. Some filters score that as spam.

Now falls back to the enrollment doc id (`enrollment-<id>`) for enrollment emails, and a timestamped placeholder (`payment-<ts>`) for payment-handler emails. Both produce valid Message-IDs in all cases.

### 2. Add `Auto-Submitted: auto-generated` header

This is the standard signal that an email is a system-generated transactional message rather than bulk marketing. Helps recipient mail systems (Gmail, Outlook, Apple Mail) classify it correctly and is one of the easiest deliverability wins available.

Both changes apply to both transactional send paths in the codebase: `create-enrollment-email.ts` (the class-confirmation Firestore trigger) and `payment-handler.ts` (donation, medic, service-payment receipts).

## What this PR does NOT touch

DNS-level fixes (SPF, DKIM, DMARC) and the Firebase Trigger Email extension's SMTP provider config — those live outside this repo. Those are likely the bigger levers for deliverability. Ran a quick public-DNS audit of mountainsol.org from local: SPF includes Google Workspace, Amazon SES, and MailChannels with a `-all` hard-fail, DMARC is at `p=quarantine` with `pct=25`, and there are DKIM keys at `default._domainkey` and `google._domainkey`. Looks reasonable; the most useful next step is registering with Gmail Postmaster Tools to see actual auth/spam stats.

## Test plan

- [ ] Functions build passes locally (verified).
- [ ] Trigger an enrollment in dev with `finalCost > 0`. Confirm Cloud Logging shows the Queued log line and the resulting `mail/<id>` doc has a `Message-ID` with the transaction id (no `undefined`).
- [ ] Trigger an enrollment in dev with `finalCost === 0` (free enrollment). Confirm the `Message-ID` falls back to `enrollment-<id>` and is well-formed.
- [ ] Inspect a sent email's raw headers and confirm `Auto-Submitted: auto-generated` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)