### PR TITLE
fix: drop hardcoded backpack-list fallback when semester content is empty

### DIFF
--- a/libs/ts/enrollment-email-template/src/lib/render-enrollment-email.ts
+++ b/libs/ts/enrollment-email-template/src/lib/render-enrollment-email.ts
@@ -49,13 +49,6 @@ export interface EnrollmentEmailContent {
     text: string;
 }
 
-const DEFAULT_BACKPACK_ITEMS = [
-    'Water bottle',
-    'Peanut-free snack',
-    'Bugspray/sunscreen',
-    'Rain jacket',
-];
-
 const STYLES = `
     body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
     table { width: 100%; border-collapse: collapse; margin: 20px 0; }
@@ -73,32 +66,27 @@ function renderSemesterContentHtml(
     semester: EmailSemester,
     showSemesterHeader: boolean
 ): string {
+    if (!semester.enrollmentEmailContent?.trim()) {
+        return '';
+    }
     const heading = showSemesterHeader
         ? `<h3 style="margin-bottom: 4px;">${semester.name}</h3>`
         : '';
-    if (semester.enrollmentEmailContent?.trim()) {
-        const rendered = marked.parse(semester.enrollmentEmailContent, {
-            async: false,
-        }) as string;
-        return `${heading}<div>${rendered}</div>`;
-    }
-    const list = `<ul>${DEFAULT_BACKPACK_ITEMS.map(
-        (item) => `<li>${item}</li>`
-    ).join('')}</ul>`;
-    const intro = `<p>Here's a quick reminder of what your student should bring in their backpack:</p>`;
-    return `${heading}${intro}${list}`;
+    const rendered = marked.parse(semester.enrollmentEmailContent, {
+        async: false,
+    }) as string;
+    return `${heading}<div>${rendered}</div>`;
 }
 
 function renderSemesterContentText(
     semester: EmailSemester,
     showSemesterHeader: boolean
 ): string {
-    const heading = showSemesterHeader ? `${semester.name}\n` : '';
-    if (semester.enrollmentEmailContent?.trim()) {
-        return `${heading}${semester.enrollmentEmailContent.trim()}\n`;
+    if (!semester.enrollmentEmailContent?.trim()) {
+        return '';
     }
-    const list = DEFAULT_BACKPACK_ITEMS.map((item) => `• ${item}`).join('\n');
-    return `${heading}Here's a quick reminder of what your student should bring in their backpack:\n${list}\n`;
+    const heading = showSemesterHeader ? `${semester.name}\n` : '';
+    return `${heading}${semester.enrollmentEmailContent.trim()}\n`;
 }
 
 function renderAttachmentsHtml(attachments: Array<EmailAttachment>): string {
@@ -155,10 +143,13 @@ export function renderEnrollmentEmail(
         ? `<p>This is a confirmation of changes to ${studentName}'s enrollment.</p>`
         : `<p>Hey there! Thanks for signing up ${studentName} for classes!</p>`;
 
-    const showSemesterHeaders = semesters.length > 1;
+    const semestersWithContent = semesters.filter((s) =>
+        s.enrollmentEmailContent?.trim()
+    );
+    const showSemesterHeaders = semestersWithContent.length > 1;
     const semesterSectionsHtml = isAddendum
         ? ''
-        : semesters
+        : semestersWithContent
               .map((s) => renderSemesterContentHtml(s, showSemesterHeaders))
               .join('');
     const backpackSection = isAddendum
@@ -267,7 +258,7 @@ export function renderEnrollmentEmail(
 
     const semesterSectionsPlain = isAddendum
         ? ''
-        : semesters
+        : semestersWithContent
               .map((s) => renderSemesterContentText(s, showSemesterHeaders))
               .join('\n');
     const backpackSectionPlain = isAddendum


### PR DESCRIPTION
## Summary

The previous behavior surfaced a generic "Water bottle / Peanut-free snack / Bugspray-sunscreen / Rain jacket" list whenever a semester had no \`enrollmentEmailContent\`. That was a transitional fallback for the period before staff started filling content in; now that the editor is shipped and the source of truth, baking outdated generic copy into the template is wrong — it sneaks unedited content into emails for semesters where staff intentionally left the field empty.

## Behavior change

- Empty content for a semester → **no section rendered** for that semester.
- Filtering on non-empty content also drives the multi-semester header decision: if only one semester out of two has content, the email shows that block **without** a semester header (one-block presentation), instead of dragging in an unwanted second block under a header.
- Surrounding "Got questions? Reply to this email…" paragraph still renders regardless. Receipt, transaction details, footer all unchanged.

## Test plan

- [ ] Editor preview for a semester with empty content shows no "what to bring" section. Surrounding template (intro, "Got questions", receipt) still renders.
- [ ] Editor preview for a semester with content shows the rendered markdown.
- [ ] Real enrollment for a semester with empty content produces an email with no "what to bring" section.
- [ ] Multi-semester enrollment where only one semester has content: email shows that block without a semester header (single-block layout).
- [ ] Multi-semester enrollment where both have content: email shows two sections under semester names as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)