### PR TITLE
chore: clear pre-existing lint backlog (~282 errors)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,13 @@
                                 "sourceTag": "*",
                                 "onlyDependOnLibsWithTags": ["*"]
                             }
+                        ],
+                        "ignoredCircularDependencies": [
+                            ["enrollment-portal", "angular-admin-discounts"],
+                            [
+                                "enrollment-portal",
+                                "angular-admin-enrollment-messages"
+                            ]
                         ]
                     }
                 ]
@@ -56,6 +63,21 @@
             "rules": {
                 "@typescript-eslint/no-extra-semi": "error",
                 "no-extra-semi": "off"
+            }
+        },
+        {
+            "files": ["*.tsx"],
+            "parser": "@typescript-eslint/parser",
+            "parserOptions": {
+                "ecmaVersion": "latest",
+                "sourceType": "module",
+                "ecmaFeatures": { "jsx": true }
+            }
+        },
+        {
+            "files": ["**/*.stories.ts", "**/*.stories.tsx"],
+            "rules": {
+                "@nx/enforce-module-boundaries": "off"
             }
         },
         {

--- a/.nxignore
+++ b/.nxignore
@@ -1,3 +1,6 @@
 # Nx-Firebase
 !.secret.local
 !.runtimeconfig.json
+
+# Claude Code local worktrees (duplicate project.json files would collide with the main tree)
+.claude/worktrees

--- a/apps/enrollment-portal/.eslintrc.json
+++ b/apps/enrollment-portal/.eslintrc.json
@@ -32,6 +32,14 @@
             "files": ["*.html"],
             "extends": ["plugin:@nx/angular-template"],
             "rules": {}
+        },
+        {
+            "files": [".storybook/**/*.ts"],
+            "parserOptions": {
+                "project": [
+                    "apps/enrollment-portal/.storybook/tsconfig.storybook.json"
+                ]
+            }
         }
     ]
 }

--- a/apps/enrollment-portal/.storybook/mocks/api-service.mock.ts
+++ b/apps/enrollment-portal/.storybook/mocks/api-service.mock.ts
@@ -28,7 +28,9 @@ export function createMockApiService(
         getEnrollmentMessages: (() =>
             of({ messages: [] })) as MockApiService['getEnrollmentMessages'],
         getEnrollmentMessagesAdmin: (() =>
-            of({ messages: [] })) as MockApiService['getEnrollmentMessagesAdmin'],
+            of({
+                messages: [],
+            })) as MockApiService['getEnrollmentMessagesAdmin'],
         updateEnrollmentMessages: (() =>
             of({
                 success: true,

--- a/apps/enrollment-portal/src/app/app-routes.ts
+++ b/apps/enrollment-portal/src/app/app-routes.ts
@@ -101,9 +101,7 @@ export const appRoutes: Routes = [
                                         loadChildren: () =>
                                             import(
                                                 '@sol/angular/admin/discounts'
-                                            ).then(
-                                                (m) => m.discountRoutes
-                                            ),
+                                            ).then((m) => m.discountRoutes),
                                     },
                                     {
                                         path: 'messages',

--- a/apps/enrollment-portal/src/app/donate-full.component.ts
+++ b/apps/enrollment-portal/src/app/donate-full.component.ts
@@ -159,7 +159,9 @@ import { MatDialogModule } from '@angular/material/dialog';
                                     <input
                                         type="number"
                                         [ngModel]="donationAmount()"
-                                        (ngModelChange)="donationAmount.set($event)"
+                                        (ngModelChange)="
+                                            donationAmount.set($event)
+                                        "
                                         name="donationAmount"
                                         placeholder="25.00"
                                         min="1"

--- a/apps/enrollment-portal/src/app/donate.component.ts
+++ b/apps/enrollment-portal/src/app/donate.component.ts
@@ -210,7 +210,11 @@ import * as browserDetection from '@braintree/browser-detection';
                 font-size: 1.1rem;
                 font-weight: 600;
                 border-radius: 0.5rem;
-                background: linear-gradient(135deg, var(--sol-primary) 0%, var(--sol-primary-hover) 100%);
+                background: linear-gradient(
+                    135deg,
+                    var(--sol-primary) 0%,
+                    var(--sol-primary-hover) 100%
+                );
                 border: none;
                 transition: all 0.3s ease;
             }

--- a/apps/enrollment-portal/src/main.ts
+++ b/apps/enrollment-portal/src/main.ts
@@ -6,6 +6,7 @@ import { provideRouter } from '@angular/router';
 import { provideEffects } from '@ngrx/effects';
 import { provideStore } from '@ngrx/store';
 import { authInterceptor } from '@sol/auth/interceptor';
+import { USE_REMOTE_FUNCTIONS } from '@sol/firebase/functions-api';
 import { MessageService } from 'primeng/api';
 import { appRoutes } from './app/app-routes';
 import { AppComponent } from './app/app.component';
@@ -45,5 +46,9 @@ bootstrapApplication(AppComponent, {
         provideEffects(),
         provideRouter(appRoutes),
         provideMarkdown(),
+        {
+            provide: USE_REMOTE_FUNCTIONS,
+            useValue: environment.remoteFunctions,
+        },
     ],
 });

--- a/apps/student-portal/.eslintrc.json
+++ b/apps/student-portal/.eslintrc.json
@@ -24,6 +24,12 @@
         {
             "files": ["*.js", "*.jsx"],
             "rules": {}
+        },
+        {
+            "files": ["next-env.d.ts"],
+            "rules": {
+                "@typescript-eslint/triple-slash-reference": "off"
+            }
         }
     ],
     "rules": {

--- a/apps/student-portal/components/Header.tsx
+++ b/apps/student-portal/components/Header.tsx
@@ -22,61 +22,146 @@ const Header = () => {
     const mobileMenuRef = useRef<Menu>(null);
 
     const adminMenuItems = [
-        { label: 'Class Registration', url: `${ENROLLMENT_BASE}/classes/enrollment` },
+        {
+            label: 'Class Registration',
+            url: `${ENROLLMENT_BASE}/classes/enrollment`,
+        },
         { separator: true },
-        { label: 'Admin', disabled: true, style: { fontSize: '12px', opacity: 0.6 } },
+        {
+            label: 'Admin',
+            disabled: true,
+            style: { fontSize: '12px', opacity: 0.6 },
+        },
         { label: 'Dashboard', url: `${ENROLLMENT_BASE}/admin` },
-        { label: 'Manage Classes', url: `${ENROLLMENT_BASE}/admin/classes/management` },
-        { label: 'Class Forms and Contacts', url: `${ENROLLMENT_BASE}/admin/report` },
-        { label: 'Student Info Sheets', url: `${ENROLLMENT_BASE}/admin/students` },
+        {
+            label: 'Manage Classes',
+            url: `${ENROLLMENT_BASE}/admin/classes/management`,
+        },
+        {
+            label: 'Class Forms and Contacts',
+            url: `${ENROLLMENT_BASE}/admin/report`,
+        },
+        {
+            label: 'Student Info Sheets',
+            url: `${ENROLLMENT_BASE}/admin/students`,
+        },
         { label: 'T-shirt Sizes', url: `${ENROLLMENT_BASE}/admin/t-shirts` },
         { label: 'Enrollments', url: `${ENROLLMENT_BASE}/admin/enrollments` },
         { label: 'Class Calendar', url: `${ENROLLMENT_BASE}/calendar/classes` },
         { label: 'Student Units', command: () => router.push('/units') },
-        ...(isMedicAdmin ? [
-            { separator: true },
-            { label: 'Medic Admin', disabled: true, style: { fontSize: '12px', opacity: 0.6 } },
-            { label: 'Manage Medic Classes', url: `${ENROLLMENT_BASE}/medic/admin/classes` },
-            { label: 'Medic Enrollments', url: `${ENROLLMENT_BASE}/medic/admin/enrollments` },
-        ] : []),
+        ...(isMedicAdmin
+            ? [
+                  { separator: true },
+                  {
+                      label: 'Medic Admin',
+                      disabled: true,
+                      style: { fontSize: '12px', opacity: 0.6 },
+                  },
+                  {
+                      label: 'Manage Medic Classes',
+                      url: `${ENROLLMENT_BASE}/medic/admin/classes`,
+                  },
+                  {
+                      label: 'Medic Enrollments',
+                      url: `${ENROLLMENT_BASE}/medic/admin/enrollments`,
+                  },
+              ]
+            : []),
     ];
 
     const emailDisplay = user?.email
-        ? (user.email.length > 20 ? user.email.substring(0, 20) + '...' : user.email)
+        ? user.email.length > 20
+            ? user.email.substring(0, 20) + '...'
+            : user.email
         : 'User';
 
-    const userMenuItems = user ? [
-        { label: emailDisplay, disabled: true },
-        { separator: true },
-        { label: 'Sign Out', icon: 'pi pi-sign-out', command: () => signOut() },
-    ] : [];
+    const userMenuItems = user
+        ? [
+              { label: emailDisplay, disabled: true },
+              { separator: true },
+              {
+                  label: 'Sign Out',
+                  icon: 'pi pi-sign-out',
+                  command: () => signOut(),
+              },
+          ]
+        : [];
 
     const mobileMenuItems = [
-        ...(user ? [
-            { label: emailDisplay, disabled: true },
-            { separator: true },
-            { label: 'Sign Out', icon: 'pi pi-sign-out', command: () => signOut() },
-        ] : [
-            { label: 'Register / Sign In', icon: 'pi pi-sign-in', command: () => router.push('/user/create') },
-        ]),
-        ...(isAdmin ? [
-            { separator: true },
-            { label: 'Admin', disabled: true, style: { fontSize: '12px', opacity: 0.6 } },
-            { label: 'Dashboard', url: `${ENROLLMENT_BASE}/admin` },
-            { label: 'Manage Classes', url: `${ENROLLMENT_BASE}/admin/classes/management` },
-            { label: 'Class Forms and Contacts', url: `${ENROLLMENT_BASE}/admin/report` },
-            { label: 'Student Info Sheets', url: `${ENROLLMENT_BASE}/admin/students` },
-            { label: 'T-shirt Sizes', url: `${ENROLLMENT_BASE}/admin/t-shirts` },
-            { label: 'Enrollments', url: `${ENROLLMENT_BASE}/admin/enrollments` },
-            { label: 'Class Calendar', url: `${ENROLLMENT_BASE}/calendar/classes` },
-            { label: 'Student Units', command: () => router.push('/units') },
-        ] : []),
-        ...(isMedicAdmin ? [
-            { separator: true },
-            { label: 'Medic Admin', disabled: true, style: { fontSize: '12px', opacity: 0.6 } },
-            { label: 'Manage Medic Classes', url: `${ENROLLMENT_BASE}/medic/admin/classes` },
-            { label: 'Medic Enrollments', url: `${ENROLLMENT_BASE}/medic/admin/enrollments` },
-        ] : []),
+        ...(user
+            ? [
+                  { label: emailDisplay, disabled: true },
+                  { separator: true },
+                  {
+                      label: 'Sign Out',
+                      icon: 'pi pi-sign-out',
+                      command: () => signOut(),
+                  },
+              ]
+            : [
+                  {
+                      label: 'Register / Sign In',
+                      icon: 'pi pi-sign-in',
+                      command: () => router.push('/user/create'),
+                  },
+              ]),
+        ...(isAdmin
+            ? [
+                  { separator: true },
+                  {
+                      label: 'Admin',
+                      disabled: true,
+                      style: { fontSize: '12px', opacity: 0.6 },
+                  },
+                  { label: 'Dashboard', url: `${ENROLLMENT_BASE}/admin` },
+                  {
+                      label: 'Manage Classes',
+                      url: `${ENROLLMENT_BASE}/admin/classes/management`,
+                  },
+                  {
+                      label: 'Class Forms and Contacts',
+                      url: `${ENROLLMENT_BASE}/admin/report`,
+                  },
+                  {
+                      label: 'Student Info Sheets',
+                      url: `${ENROLLMENT_BASE}/admin/students`,
+                  },
+                  {
+                      label: 'T-shirt Sizes',
+                      url: `${ENROLLMENT_BASE}/admin/t-shirts`,
+                  },
+                  {
+                      label: 'Enrollments',
+                      url: `${ENROLLMENT_BASE}/admin/enrollments`,
+                  },
+                  {
+                      label: 'Class Calendar',
+                      url: `${ENROLLMENT_BASE}/calendar/classes`,
+                  },
+                  {
+                      label: 'Student Units',
+                      command: () => router.push('/units'),
+                  },
+              ]
+            : []),
+        ...(isMedicAdmin
+            ? [
+                  { separator: true },
+                  {
+                      label: 'Medic Admin',
+                      disabled: true,
+                      style: { fontSize: '12px', opacity: 0.6 },
+                  },
+                  {
+                      label: 'Manage Medic Classes',
+                      url: `${ENROLLMENT_BASE}/medic/admin/classes`,
+                  },
+                  {
+                      label: 'Medic Enrollments',
+                      url: `${ENROLLMENT_BASE}/medic/admin/enrollments`,
+                  },
+              ]
+            : []),
     ];
 
     const iconButtonStyle: React.CSSProperties = {
@@ -121,7 +206,7 @@ const Header = () => {
     const rightContents = (
         <div className="flex items-center">
             {isDesktop ? (
-                (isAdmin || isMedicAdmin) ? (
+                isAdmin || isMedicAdmin ? (
                     <div style={splitButtonStyle}>
                         <Button
                             icon="pi pi-bars"
@@ -140,7 +225,13 @@ const Header = () => {
                         ) : (
                             <Button
                                 label="Sign In"
-                                style={{ ...iconButtonStyle, width: 'auto', padding: '0 12px', fontSize: '14px', fontWeight: 500 }}
+                                style={{
+                                    ...iconButtonStyle,
+                                    width: 'auto',
+                                    padding: '0 12px',
+                                    fontSize: '14px',
+                                    fontWeight: 500,
+                                }}
                                 onClick={() => router.push('/user/create')}
                             />
                         )}
@@ -150,13 +241,21 @@ const Header = () => {
                         size="large"
                         icon="pi pi-user"
                         onClick={(e) => userMenuRef.current?.toggle(e)}
-                        style={{ backgroundColor: 'rgba(255,255,255,0.2)', color: '#fff', cursor: 'pointer' }}
+                        style={{
+                            backgroundColor: 'rgba(255,255,255,0.2)',
+                            color: '#fff',
+                            cursor: 'pointer',
+                        }}
                     />
                 ) : (
                     <Button
                         onClick={() => router.push('/user/create')}
                         label="Register / Sign In"
-                        style={{ background: 'transparent', border: '1px solid #fff', color: '#fff' }}
+                        style={{
+                            background: 'transparent',
+                            border: '1px solid #fff',
+                            color: '#fff',
+                        }}
                     />
                 )
             ) : (

--- a/apps/student-portal/components/units/student/StudentUnitsPage.tsx
+++ b/apps/student-portal/components/units/student/StudentUnitsPage.tsx
@@ -25,9 +25,15 @@ export function StudentUnitsPage({ studentId }: StudentUnitsPageProps) {
     return (
         <div className="student-units-page">
             <div className="tree-container">
-                <SmartTreeChart studentId={studentId} onUnitSelect={handleUnitSelect} />
+                <SmartTreeChart
+                    studentId={studentId}
+                    onUnitSelect={handleUnitSelect}
+                />
             </div>
-            <UnitDetailsPanel unitDetails={selectedUnit} isSelected={isUnitSelected} />
+            <UnitDetailsPanel
+                unitDetails={selectedUnit}
+                isSelected={isUnitSelected}
+            />
         </div>
     );
 }

--- a/apps/student-portal/components/units/update/UpdateUnitsTool.tsx
+++ b/apps/student-portal/components/units/update/UpdateUnitsTool.tsx
@@ -413,9 +413,7 @@ export function UpdateUnitsTool(props: {
                         </h2>
                         {units.map((unit) => (
                             <div key={unit.id} className="mb-4">
-                                <h3 className="font-semibold">
-                                    {unit.name}
-                                </h3>
+                                <h3 className="font-semibold">{unit.name}</h3>
                                 <p>{unit.description}</p>
                             </div>
                         ))}

--- a/libs/angular/account/src/lib/components/enrollments/account-enrollments.component.ts
+++ b/libs/angular/account/src/lib/components/enrollments/account-enrollments.component.ts
@@ -6,9 +6,7 @@ import { AccountEnrollmentsApiService } from '../../services/account-enrollments
 import { EnrollmentComponent } from './enrollment.component';
 import { EnrollmentSkeletonComponent } from './enrollment-skeleton.component';
 import { ClassesSemesterListService } from '@sol/angular/classes/semester-list';
-import {
-    RequestedOperatorsUtility,
-} from '@sol/angular/request';
+import { RequestedOperatorsUtility } from '@sol/angular/request';
 import { map } from 'rxjs';
 
 @Component({

--- a/libs/angular/admin/discounts/src/lib/components/confirm-delete-dialog.stories.ts
+++ b/libs/angular/admin/discounts/src/lib/components/confirm-delete-dialog.stories.ts
@@ -15,7 +15,7 @@ const meta: Meta<ConfirmDeleteDialogComponent> = {
                 },
                 {
                     provide: DialogRef,
-                    useValue: { close: () => {} },
+                    useValue: { close: () => undefined },
                 },
             ],
         }),

--- a/libs/angular/admin/enrollment-messages/src/lib/components/enrollment-messages-editor.component.ts
+++ b/libs/angular/admin/enrollment-messages/src/lib/components/enrollment-messages-editor.component.ts
@@ -126,9 +126,7 @@ let nextId = 0;
                     <mat-card class="message-card">
                         <mat-card-content>
                             <div class="message-header">
-                                <span class="message-number"
-                                    >#{{ i + 1 }}</span
-                                >
+                                <span class="message-number">#{{ i + 1 }}</span>
                                 <mat-slide-toggle
                                     [ngModel]="msg.active"
                                     (ngModelChange)="
@@ -148,9 +146,7 @@ let nextId = 0;
 
                             <sol-markdown-editor
                                 [ngModel]="msg.text"
-                                (ngModelChange)="
-                                    updateField(i, 'text', $event)
-                                "
+                                (ngModelChange)="updateField(i, 'text', $event)"
                                 placeholder="Use **bold** for emphasis, [link](url) for links"
                                 [rows]="3"
                             ></sol-markdown-editor>
@@ -161,11 +157,7 @@ let nextId = 0;
                                     <mat-select
                                         [ngModel]="msg.severity"
                                         (ngModelChange)="
-                                            updateField(
-                                                i,
-                                                'severity',
-                                                $event
-                                            )
+                                            updateField(i, 'severity', $event)
                                         "
                                     >
                                         @for (
@@ -186,11 +178,7 @@ let nextId = 0;
                                         [matDatepicker]="startPicker"
                                         [ngModel]="msg.startDate"
                                         (ngModelChange)="
-                                            updateField(
-                                                i,
-                                                'startDate',
-                                                $event
-                                            )
+                                            updateField(i, 'startDate', $event)
                                         "
                                     />
                                     <mat-datepicker-toggle
@@ -209,20 +197,14 @@ let nextId = 0;
                                         [matDatepicker]="endPicker"
                                         [ngModel]="msg.endDate"
                                         (ngModelChange)="
-                                            updateField(
-                                                i,
-                                                'endDate',
-                                                $event
-                                            )
+                                            updateField(i, 'endDate', $event)
                                         "
                                     />
                                     <mat-datepicker-toggle
                                         matIconSuffix
                                         [for]="endPicker"
                                     ></mat-datepicker-toggle>
-                                    <mat-datepicker
-                                        #endPicker
-                                    ></mat-datepicker>
+                                    <mat-datepicker #endPicker></mat-datepicker>
                                 </mat-form-field>
                             </div>
                         </mat-card-content>
@@ -324,8 +306,7 @@ export class EnrollmentMessagesEditorComponent {
     });
 
     readonly messagesResource = rxResource({
-        stream: () =>
-            this.#api.getEnrollmentMessagesAdmin(undefined as never),
+        stream: () => this.#api.getEnrollmentMessagesAdmin(undefined as never),
     });
 
     readonly loading = computed(
@@ -368,15 +349,9 @@ export class EnrollmentMessagesEditorComponent {
         this.messages.update((msgs) => msgs.filter((_, i) => i !== index));
     }
 
-    updateField(
-        index: number,
-        field: keyof MessageForm,
-        value: unknown
-    ) {
+    updateField(index: number, field: keyof MessageForm, value: unknown) {
         this.messages.update((msgs) =>
-            msgs.map((m, i) =>
-                i === index ? { ...m, [field]: value } : m
-            )
+            msgs.map((m, i) => (i === index ? { ...m, [field]: value } : m))
         );
     }
 

--- a/libs/angular/admin/enrollments/src/lib/components/confirm-revoke-dialog.component.ts
+++ b/libs/angular/admin/enrollments/src/lib/components/confirm-revoke-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, computed, effect } from '@angular/core';
+import { Component, inject, signal, computed } from '@angular/core';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -81,7 +81,9 @@ interface ClassSelection {
                                         min="0"
                                         step="0.01"
                                         [ngModel]="refundAmountInput()"
-                                        (ngModelChange)="refundAmountInput.set($event)"
+                                        (ngModelChange)="
+                                            refundAmountInput.set($event)
+                                        "
                                         class="refund-input"
                                     />
                                 </div>
@@ -95,7 +97,9 @@ interface ClassSelection {
                                 <p class="revoke-note">
                                     Student will remain enrolled in
                                     {{ remainingCount() }}
-                                    class{{ remainingCount() === 1 ? '' : 'es' }}.
+                                    class{{
+                                        remainingCount() === 1 ? '' : 'es'
+                                    }}.
                                 </p>
                             }
                         }
@@ -110,7 +114,9 @@ interface ClassSelection {
                 <button
                     mat-raised-button
                     color="warn"
-                    [disabled]="selectedCount() === 0 || loading() || previewLoading()"
+                    [disabled]="
+                        selectedCount() === 0 || loading() || previewLoading()
+                    "
                     (click)="confirm()"
                 >
                     Revoke & Refund
@@ -124,7 +130,8 @@ interface ClassSelection {
                 display: block;
                 background: white;
                 border-radius: 8px;
-                box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2),
+                box-shadow:
+                    0 11px 15px -7px rgba(0, 0, 0, 0.2),
                     0 24px 38px 3px rgba(0, 0, 0, 0.14),
                     0 9px 46px 8px rgba(0, 0, 0, 0.12);
             }
@@ -188,7 +195,9 @@ interface ClassSelection {
 })
 export class ConfirmRevokeDialogComponent {
     readonly data = inject<ConfirmRevokeDialogData>(DIALOG_DATA);
-    readonly dialogRef = inject(DialogRef<ConfirmRevokeDialogResult | undefined>);
+    readonly dialogRef = inject(
+        DialogRef<ConfirmRevokeDialogResult | undefined>
+    );
     readonly #api = inject(MountainSolApiService);
 
     readonly loading = signal(true);

--- a/libs/angular/admin/enrollments/src/lib/components/enrollments.component.ts
+++ b/libs/angular/admin/enrollments/src/lib/components/enrollments.component.ts
@@ -1,6 +1,19 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    inject,
+    signal,
+} from '@angular/core';
 import { FirebaseFunctionsService } from '@sol/firebase/functions-api';
-import { Observable, map, shareReplay, firstValueFrom, Subject, switchMap, startWith } from 'rxjs';
+import {
+    Observable,
+    map,
+    shareReplay,
+    firstValueFrom,
+    Subject,
+    switchMap,
+    startWith,
+} from 'rxjs';
 import { AsyncPipe, CurrencyPipe, DatePipe } from '@angular/common';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { TableModule } from 'primeng/table';
@@ -45,9 +58,7 @@ export class EnrollmentsComponent {
         switchMap(() =>
             this.#functions
                 .call<Array<SemesterEnrollment>>('adminEnrollments')
-                .pipe(
-                    RequestedOperatorsUtility.ignoreAllStatesButLoaded(),
-                )
+                .pipe(RequestedOperatorsUtility.ignoreAllStatesButLoaded())
         ),
         map((enrollments) => {
             return enrollments
@@ -58,8 +69,7 @@ export class EnrollmentsComponent {
                     date: enrollment.timestamp._seconds * 1000,
                     ...enrollment.discounts
                         .map((discount, i) => ({
-                            [`discount${i}_description`]:
-                                discount.description,
+                            [`discount${i}_description`]: discount.description,
                             [`discount${i}_amount`]: discount.amount,
                         }))
                         .reduce((acc, cur) => ({ ...acc, ...cur }), {}),
@@ -100,9 +110,7 @@ export class EnrollmentsComponent {
     );
 
     async confirmRevoke(enrollment: SemesterEnrollment & { date: number }) {
-        const classes = 'classes' in enrollment
-            ? enrollment.classes
-            : [];
+        const classes = 'classes' in enrollment ? enrollment.classes : [];
 
         const dialogRef = this.#dialog.open<
             ConfirmRevokeDialogResult | undefined,

--- a/libs/angular/braintree-client/src/lib/components/payment-collector/payment-collector.store.ts
+++ b/libs/angular/braintree-client/src/lib/components/payment-collector/payment-collector.store.ts
@@ -190,14 +190,19 @@ export class PaymentCollectorStore extends ComponentStore<{
                                             // For fresh card entry: paymentMethodIsSelected is false, but type is 'CreditCard'
                                             // For Venmo: type is 'VenmoAccount'
                                             if (
-                                                this.get().readyForUserInteraction
+                                                this.get()
+                                                    .readyForUserInteraction
                                             ) {
-                                                if (event.paymentMethodIsSelected) {
+                                                if (
+                                                    event.paymentMethodIsSelected
+                                                ) {
                                                     // Vaulted payment method selected - tokenize immediately
                                                     this.prepare();
                                                 } else if (
-                                                    event.type === 'CreditCard' ||
-                                                    event.type === 'VenmoAccount'
+                                                    event.type ===
+                                                        'CreditCard' ||
+                                                    event.type ===
+                                                        'VenmoAccount'
                                                 ) {
                                                     // Fresh card/Venmo - tokenize after a short delay
                                                     // to ensure the Drop-in UI has settled

--- a/libs/angular/classes/class-enrollment/src/lib/components/acknowledge-out-of-date/acknowledge-out-of-date.component.ts
+++ b/libs/angular/classes/class-enrollment/src/lib/components/acknowledge-out-of-date/acknowledge-out-of-date.component.ts
@@ -43,7 +43,8 @@ export class AcknowledgeOutOfDateComponent {
 
     readonly isOutOfDateAndNotAcknowledged = this.#workflow.selectSignal(
         (state) =>
-            !state.hasAcknowledgedOutOfDate && state.doesStudentInfoRequireReview
+            !state.hasAcknowledgedOutOfDate &&
+            state.doesStudentInfoRequireReview
     );
 
     acknowledgeOutOfDate() {

--- a/libs/angular/classes/class-enrollment/src/lib/components/classes/class-card/class-card.component.spec.ts
+++ b/libs/angular/classes/class-enrollment/src/lib/components/classes/class-card/class-card.component.spec.ts
@@ -57,9 +57,7 @@ describe('ClassCardComponent', () => {
         });
 
         it('should display the "Full" badge', () => {
-            const badge = fixture.debugElement.query(
-                By.css('.full-badge')
-            );
+            const badge = fixture.debugElement.query(By.css('.full-badge'));
             expect(badge).toBeTruthy();
             expect(badge.nativeElement.textContent.trim()).toBe('Full');
         });
@@ -75,32 +73,24 @@ describe('ClassCardComponent', () => {
         });
 
         it('should disable the select button', () => {
-            const button = fixture.debugElement.query(
-                By.css('.select-button')
-            );
+            const button = fixture.debugElement.query(By.css('.select-button'));
             expect(button).toBeTruthy();
             expect(button.nativeElement.disabled).toBe(true);
         });
 
         it('should show "Class Full" text on the button', () => {
-            const button = fixture.debugElement.query(
-                By.css('.select-button')
-            );
+            const button = fixture.debugElement.query(By.css('.select-button'));
             expect(button.nativeElement.textContent).toContain('Class Full');
         });
 
         it('should apply grayscale to the header image', () => {
-            const header = fixture.debugElement.query(
-                By.css('.card-header')
-            );
+            const header = fixture.debugElement.query(By.css('.card-header'));
             expect(header.nativeElement.classList).toContain('grayscale');
         });
 
         it('should not emit selectedChange when trying to select', () => {
             const spy = jest.spyOn(component.selectedChange, 'emit');
-            const button = fixture.debugElement.query(
-                By.css('.select-button')
-            );
+            const button = fixture.debugElement.query(By.css('.select-button'));
             button.nativeElement.click();
             expect(spy).not.toHaveBeenCalled();
         });
@@ -116,9 +106,7 @@ describe('ClassCardComponent', () => {
         });
 
         it('should not display the "Full" badge', () => {
-            const badge = fixture.debugElement.query(
-                By.css('.full-badge')
-            );
+            const badge = fixture.debugElement.query(By.css('.full-badge'));
             expect(badge).toBeNull();
         });
 
@@ -130,32 +118,24 @@ describe('ClassCardComponent', () => {
         });
 
         it('should enable the select button', () => {
-            const button = fixture.debugElement.query(
-                By.css('.select-button')
-            );
+            const button = fixture.debugElement.query(By.css('.select-button'));
             expect(button).toBeTruthy();
             expect(button.nativeElement.disabled).toBe(false);
         });
 
         it('should show "Select Class" text on the button', () => {
-            const button = fixture.debugElement.query(
-                By.css('.select-button')
-            );
+            const button = fixture.debugElement.query(By.css('.select-button'));
             expect(button.nativeElement.textContent).toContain('Select Class');
         });
 
         it('should not apply grayscale to the header image', () => {
-            const header = fixture.debugElement.query(
-                By.css('.card-header')
-            );
+            const header = fixture.debugElement.query(By.css('.card-header'));
             expect(header.nativeElement.classList).not.toContain('grayscale');
         });
 
         it('should emit selectedChange when selecting', () => {
             const spy = jest.spyOn(component.selectedChange, 'emit');
-            const button = fixture.debugElement.query(
-                By.css('.select-button')
-            );
+            const button = fixture.debugElement.query(By.css('.select-button'));
             button.nativeElement.click();
             fixture.detectChanges();
             expect(spy).toHaveBeenCalledWith(
@@ -216,9 +196,7 @@ describe('ClassCardComponent', () => {
         });
 
         it('should disable the select button when full', () => {
-            const button = fixture.debugElement.query(
-                By.css('.select-button')
-            );
+            const button = fixture.debugElement.query(By.css('.select-button'));
             expect(button).toBeTruthy();
             expect(button.nativeElement.disabled).toBe(true);
         });

--- a/libs/angular/classes/class-enrollment/src/lib/components/classes/class-card/class-card.component.ts
+++ b/libs/angular/classes/class-enrollment/src/lib/components/classes/class-card/class-card.component.ts
@@ -418,7 +418,6 @@ export class ClassCardComponent {
         );
     });
 
-
     readonly fallbackImageUrl =
         'https://firebasestorage.googleapis.com/v0/b/mountain-sol-platform.appspot.com/o/default_class.png?alt=media&token=258cef64-a8b9-416b-855c-51bb57a86b37';
 

--- a/libs/angular/classes/class-enrollment/src/lib/components/classes/class-list/class-list.component.ts
+++ b/libs/angular/classes/class-enrollment/src/lib/components/classes/class-list/class-list.component.ts
@@ -345,14 +345,19 @@ export class ClassesComponent {
                                           c.id
                                       ] ?? [];
                                   const lockedOptIds =
-                                      this.lockedAdditionalOptionIdsByClassId()[c.id] ?? [];
+                                      this.lockedAdditionalOptionIdsByClassId()[
+                                          c.id
+                                      ] ?? [];
                                   return {
                                       ...c,
-                                      selected: this.selectedClassIds().includes(
-                                          c.id
-                                      ),
+                                      selected:
+                                          this.selectedClassIds().includes(
+                                              c.id
+                                          ),
                                       userCost:
-                                          this.userCostsToSelectedClassIds()[c.id],
+                                          this.userCostsToSelectedClassIds()[
+                                              c.id
+                                          ],
                                       initialCost: c.cost,
                                       additionalCost:
                                           (c.additionalOptions ?? [])
@@ -363,17 +368,19 @@ export class ClassesComponent {
                                                   (agg, o) => agg + o.cost,
                                                   0
                                               ) ?? 0,
-                                      newOptionsCost:
-                                          (c.additionalOptions ?? [])
-                                              .filter(
-                                                  (option) =>
-                                                      additional.includes(option.id) &&
-                                                      !lockedOptIds.includes(option.id)
-                                              )
-                                              .reduce(
-                                                  (agg, o) => agg + o.cost,
-                                                  0
-                                              ),
+                                      newOptionsCost: (
+                                          c.additionalOptions ?? []
+                                      )
+                                          .filter(
+                                              (option) =>
+                                                  additional.includes(
+                                                      option.id
+                                                  ) &&
+                                                  !lockedOptIds.includes(
+                                                      option.id
+                                                  )
+                                          )
+                                          .reduce((agg, o) => agg + o.cost, 0),
                                   };
                               }),
                           }));
@@ -399,9 +406,11 @@ export class ClassesComponent {
     selectedDiscountClasses = computed(() => {
         const discount = this.multiClassDiscount();
         if (!discount) return [];
-        return this.selectedClasses()?.filter((c) =>
-            discount.classTypes.includes(c.classType)
-        ) ?? [];
+        return (
+            this.selectedClasses()?.filter((c) =>
+                discount.classTypes.includes(c.classType)
+            ) ?? []
+        );
     });
 
     hasSelectedDiscountClass = computed(
@@ -425,7 +434,8 @@ export class ClassesComponent {
         }
         this.workflow.patchState((s) => {
             const lockedOptionIds =
-                this.lockedAdditionalOptionIdsByClassId()[classSelection.id] ?? [];
+                this.lockedAdditionalOptionIdsByClassId()[classSelection.id] ??
+                [];
             const mergedOptionIds = selected
                 ? Array.from(
                       new Set([

--- a/libs/angular/classes/class-enrollment/src/lib/components/classes/class-row/class-row.component.ts
+++ b/libs/angular/classes/class-enrollment/src/lib/components/classes/class-row/class-row.component.ts
@@ -285,7 +285,6 @@ export class ClassRowComponent {
         return this.lockedAdditionalOptionIdsByClassId()[classId] ?? [];
     }
 
-
     readonly beforeSelectOptionsByClass = computed(() => {
         const locked = this.lockedClassIds();
         const lockedOptions = this.lockedAdditionalOptionIdsByClassId();

--- a/libs/angular/classes/class-enrollment/src/lib/components/confirm-accuracy/confirm-accuracy.component.ts
+++ b/libs/angular/classes/class-enrollment/src/lib/components/confirm-accuracy/confirm-accuracy.component.ts
@@ -27,7 +27,10 @@ import { MessagesComponent } from '@sol/form/validity';
                     I have reviewed this section and confirm it is up-to-date
                 </label>
             </div>
-            <sol-messages [messages]="messages()" variant="primeng"></sol-messages>
+            <sol-messages
+                [messages]="messages()"
+                variant="primeng"
+            ></sol-messages>
         </div>
     }`,
     imports: [CheckboxModule, FormsModule, MessagesComponent],

--- a/libs/angular/classes/class-enrollment/src/lib/components/enrollment-workflow/enrollment-workflow.store.ts
+++ b/libs/angular/classes/class-enrollment/src/lib/components/enrollment-workflow/enrollment-workflow.store.ts
@@ -172,7 +172,8 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
         (state) => ({
             addendumMode: state.addendumMode,
             lockedClassIds: state.lockedClassIds,
-            lockedAdditionalOptionIdsByClassId: state.lockedAdditionalOptionIdsByClassId,
+            lockedAdditionalOptionIdsByClassId:
+                state.lockedAdditionalOptionIdsByClassId,
         })
     );
     private readonly selectBasktCostRequest = createSelector(
@@ -198,7 +199,9 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
                             selectedAdditionalOptionIdsByClassId[id] ?? [],
                     })),
                     userCostsToClassIds,
-                    overrideCosts: undefined as Record<string, number> | undefined,
+                    overrideCosts: undefined as
+                        | Record<string, number>
+                        | undefined,
                 };
             }
             // In addendum mode, include new classes + locked classes that have new options
@@ -212,8 +215,10 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
 
             for (const c of classes) {
                 const isLocked = addendum.lockedClassIds.includes(c.id);
-                const allOptionIds = selectedAdditionalOptionIdsByClassId[c.id] ?? [];
-                const lockedOptionIds = addendum.lockedAdditionalOptionIdsByClassId[c.id] ?? [];
+                const allOptionIds =
+                    selectedAdditionalOptionIdsByClassId[c.id] ?? [];
+                const lockedOptionIds =
+                    addendum.lockedAdditionalOptionIdsByClassId[c.id] ?? [];
                 const newOptionIds = allOptionIds.filter(
                     (id) => !lockedOptionIds.includes(id)
                 );
@@ -355,18 +360,27 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
 
                         if (addendumMode && originalEnrollmentId) {
                             // Addendum submission
-                            const newClasses = enrollment.selectedClasses
-                                .filter((c) => !lockedClassIds.includes(c.id));
-                            const newAdditionalOptionIdsByClassId: Record<string, Array<string>> = {};
+                            const newClasses =
+                                enrollment.selectedClasses.filter(
+                                    (c) => !lockedClassIds.includes(c.id)
+                                );
+                            const newAdditionalOptionIdsByClassId: Record<
+                                string,
+                                Array<string>
+                            > = {};
                             for (const [classId, optionIds] of Object.entries(
                                 enrollment.additionalOptionIdsByClassId
                             )) {
-                                const locked = lockedAdditionalOptionIdsByClassId[classId] ?? [];
+                                const locked =
+                                    lockedAdditionalOptionIdsByClassId[
+                                        classId
+                                    ] ?? [];
                                 const newOpts = (optionIds ?? []).filter(
                                     (id) => !locked.includes(id)
                                 );
                                 if (newOpts.length > 0) {
-                                    newAdditionalOptionIdsByClassId[classId] = newOpts;
+                                    newAdditionalOptionIdsByClassId[classId] =
+                                        newOpts;
                                 }
                             }
                             return this.functions
@@ -381,19 +395,26 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
                                         userCostsToSelectedClassIds:
                                             enrollment.userCostsToSelectedClassIds,
                                         newAdditionalOptionIdsByClassId,
-                                        expectedTotal: state.basketCosts.finalTotal,
+                                        expectedTotal:
+                                            state.basketCosts.finalTotal,
                                     }
                                 )
                                 .pipe(
                                     tap((response) => {
-                                        if (RequestedUtility.isLoaded(response)) {
+                                        if (
+                                            RequestedUtility.isLoaded(response)
+                                        ) {
                                             this.patchState({
                                                 status: response.success
                                                     ? 'enrolled'
                                                     : 'failed',
                                             });
-                                        } else if (RequestedUtility.isError(response)) {
-                                            this.patchState({ status: 'failed' });
+                                        } else if (
+                                            RequestedUtility.isError(response)
+                                        ) {
+                                            this.patchState({
+                                                status: 'failed',
+                                            });
                                         }
                                     })
                                 );
@@ -432,9 +453,7 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
                             )
                             .pipe(
                                 tap((response) => {
-                                    if (
-                                        RequestedUtility.isLoaded(response)
-                                    ) {
+                                    if (RequestedUtility.isLoaded(response)) {
                                         this.patchState({
                                             status: response.success
                                                 ? 'enrolled'
@@ -497,7 +516,10 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
                             studentId: string;
                             studentName: string;
                             classes: Array<{ id: string; semesterId: string }>;
-                            additionalOptionIdsByClassId: Record<string, Array<string>>;
+                            additionalOptionIdsByClassId: Record<
+                                string,
+                                Array<string>
+                            >;
                             openSemesterIds: Array<string>;
                         };
                     }>('getEnrollmentForAddendum', { enrollmentId })
@@ -535,34 +557,40 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
             filter(
                 ([prev, next]) => JSON.stringify(prev) !== JSON.stringify(next)
             ),
-            switchMap(([, { codes, classes, userCostsToClassIds, overrideCosts }]) => {
-                this.patchState({ isLoadingDiscounts: true });
-                return this.functions
-                    .call<{
-                        discountAmounts: Array<{
-                            code: string;
-                            amount: number;
-                        }>;
-                        finalTotal: number;
-                        originalTotal: number;
-                    }>('calculateBasket', {
-                        codes,
-                        classes,
-                        userCostsToClassIds,
-                        ...(overrideCosts && Object.keys(overrideCosts).length > 0
-                            ? { overrideCosts }
-                            : {}),
-                    })
-                    .pipe(
-                        RequestedOperatorsUtility.ignoreAllStatesButLoaded(),
-                        tap((basketCosts) => {
-                            this.patchState(() => ({
-                                basketCosts,
-                                isLoadingDiscounts: false,
-                            }));
+            switchMap(
+                ([
+                    ,
+                    { codes, classes, userCostsToClassIds, overrideCosts },
+                ]) => {
+                    this.patchState({ isLoadingDiscounts: true });
+                    return this.functions
+                        .call<{
+                            discountAmounts: Array<{
+                                code: string;
+                                amount: number;
+                            }>;
+                            finalTotal: number;
+                            originalTotal: number;
+                        }>('calculateBasket', {
+                            codes,
+                            classes,
+                            userCostsToClassIds,
+                            ...(overrideCosts &&
+                            Object.keys(overrideCosts).length > 0
+                                ? { overrideCosts }
+                                : {}),
                         })
-                    );
-            })
+                        .pipe(
+                            RequestedOperatorsUtility.ignoreAllStatesButLoaded(),
+                            tap((basketCosts) => {
+                                this.patchState(() => ({
+                                    basketCosts,
+                                    isLoadingDiscounts: false,
+                                }));
+                            })
+                        );
+                }
+            )
         );
     });
 

--- a/libs/angular/classes/class-enrollment/src/lib/components/start-over-dialog/start-over-dialog.component.ts
+++ b/libs/angular/classes/class-enrollment/src/lib/components/start-over-dialog/start-over-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { DialogModule } from 'primeng/dialog';
 import { DialogRef } from '@angular/cdk/dialog';
 import { ButtonModule } from 'primeng/button';

--- a/libs/angular/classes/class-management/src/lib/components/class-form/class-form.component.ts
+++ b/libs/angular/classes/class-management/src/lib/components/class-form/class-form.component.ts
@@ -1,11 +1,4 @@
-import {
-    Component,
-    inject,
-    signal,
-    computed,
-    OnInit,
-    effect,
-} from '@angular/core';
+import { Component, inject, signal, computed, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
@@ -1036,7 +1029,7 @@ const WEEKDAY_OPTIONS = [
         `,
     ],
 })
-export class ClassFormComponent implements OnInit {
+export class ClassFormComponent {
     readonly #classFormService = inject(ClassFormService);
     readonly #functions = inject(FirebaseFunctionsService);
     readonly #semesterService = inject(ClassesSemesterListService);
@@ -1402,11 +1395,6 @@ export class ClassFormComponent implements OnInit {
                 this.#populateFormFromClass(result.class);
             }
         });
-    }
-
-    ngOnInit() {
-        // All data loading is now handled by rxResource declarations
-        // rxMethod for submission is connected via signal
     }
 
     #populateFormFromClass(cls: ClassForEdit) {

--- a/libs/angular/classes/class-management/src/lib/components/class-group-list/class-group-form-dialog.component.ts
+++ b/libs/angular/classes/class-management/src/lib/components/class-group-list/class-group-form-dialog.component.ts
@@ -84,9 +84,7 @@ export type ClassGroupFormDialogResult = 'saved';
                                 [disabled]="saving()"
                             >
                                 <span class="class-name">{{ cls.name }}</span>
-                                <span class="class-cost"
-                                    >\${{ cls.cost }}</span
-                                >
+                                <span class="class-cost">\${{ cls.cost }}</span>
                             </mat-checkbox>
                         </label>
                     }
@@ -252,10 +250,7 @@ export class ClassGroupFormDialogComponent implements OnInit {
     readonly savingsDisplay = computed(() => {
         const selected = this.availableClasses.filter((c) => c.selected);
         if (selected.length < 2 || this.groupCost <= 0) return null;
-        const individualTotal = selected.reduce(
-            (sum, c) => sum + c.cost,
-            0
-        );
+        const individualTotal = selected.reduce((sum, c) => sum + c.cost, 0);
         const savings = individualTotal - this.groupCost;
         if (savings <= 0) return null;
         return `$${savings} savings vs. individual prices ($${individualTotal})`;

--- a/libs/angular/classes/class-management/src/lib/components/class-group-list/class-group-list.component.ts
+++ b/libs/angular/classes/class-management/src/lib/components/class-group-list/class-group-list.component.ts
@@ -80,10 +80,7 @@ interface AdminClass {
                             [(ngModel)]="selectedSemesterId"
                             (ngModelChange)="onSemesterChange($event)"
                         >
-                            @for (
-                                semester of semesters();
-                                track semester.id
-                            ) {
+                            @for (semester of semesters(); track semester.id) {
                                 <mat-option [value]="semester.id">{{
                                     semester.name
                                 }}</mat-option>
@@ -104,8 +101,8 @@ interface AdminClass {
                         <mat-icon>group_work</mat-icon>
                         <h3>No class groups</h3>
                         <p>
-                            Class groups bundle classes together at a
-                            discounted price. Create one to get started.
+                            Class groups bundle classes together at a discounted
+                            price. Create one to get started.
                         </p>
                         <button
                             mat-raised-button
@@ -134,9 +131,7 @@ interface AdminClass {
                                         <button
                                             mat-icon-button
                                             matTooltip="Delete Group"
-                                            (click)="
-                                                confirmDeleteGroup(group)
-                                            "
+                                            (click)="confirmDeleteGroup(group)"
                                         >
                                             <mat-icon>delete</mat-icon>
                                         </button>
@@ -145,9 +140,7 @@ interface AdminClass {
 
                                 <div class="group-cost">
                                     Group Price:
-                                    <strong>{{
-                                        group.cost | currency
-                                    }}</strong>
+                                    <strong>{{ group.cost | currency }}</strong>
                                     @if (getSavings(group); as savings) {
                                         <span class="savings-badge">
                                             <mat-icon>local_offer</mat-icon>
@@ -180,7 +173,11 @@ interface AdminClass {
                 </div>
 
                 <div class="summary">
-                    <p>{{ groups().length }} group{{ groups().length !== 1 ? 's' : '' }}</p>
+                    <p>
+                        {{ groups().length }} group{{
+                            groups().length !== 1 ? 's' : ''
+                        }}
+                    </p>
                 </div>
             }
         </div>
@@ -488,8 +485,7 @@ export class ClassGroupListComponent {
             .map((c) => ({ id: c.id, name: c.name, cost: c.cost }))
             .filter(
                 (c) =>
-                    groupClassIds.has(c.id) ||
-                    !otherGroupedClassIds.has(c.id)
+                    groupClassIds.has(c.id) || !otherGroupedClassIds.has(c.id)
             );
 
         const dialogRef = this.#dialog.open<

--- a/libs/angular/classes/class-management/src/lib/components/class-list/class-detail-dialog.component.ts
+++ b/libs/angular/classes/class-management/src/lib/components/class-list/class-detail-dialog.component.ts
@@ -167,8 +167,7 @@ interface AdminClass {
                 </section>
 
                 @if (
-                    data.additionalOptions &&
-                    data.additionalOptions.length > 0
+                    data.additionalOptions && data.additionalOptions.length > 0
                 ) {
                     <mat-divider></mat-divider>
 

--- a/libs/angular/classes/class-management/src/lib/components/class-list/class-list.component.ts
+++ b/libs/angular/classes/class-management/src/lib/components/class-list/class-list.component.ts
@@ -4,7 +4,6 @@ import {
     computed,
     effect,
     linkedSignal,
-    OnInit,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -440,7 +439,7 @@ interface Semester {
         `,
     ],
 })
-export class AdminClassListComponent implements OnInit {
+export class AdminClassListComponent {
     readonly #functions = inject(FirebaseFunctionsService);
     readonly #semesterService = inject(ClassesSemesterListService);
     readonly #router = inject(Router);
@@ -551,10 +550,6 @@ export class AdminClassListComponent implements OnInit {
                 this.#updateUrlWithSemester(semesterId);
             }
         });
-    }
-
-    ngOnInit() {
-        // rxMethods are connected via their observable inputs when dialogs open
     }
 
     onSemesterChange(semesterId: string) {

--- a/libs/angular/classes/class-management/src/lib/components/info-panel-editor/info-panel-editor.component.ts
+++ b/libs/angular/classes/class-management/src/lib/components/info-panel-editor/info-panel-editor.component.ts
@@ -1,10 +1,4 @@
-import {
-    Component,
-    inject,
-    signal,
-    computed,
-    effect,
-} from '@angular/core';
+import { Component, inject, signal, computed, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
@@ -27,10 +21,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
-import {
-    InfoPanelComponent,
-    type PanelConfig,
-} from '@sol/classes/enrollment';
+import { InfoPanelComponent, type PanelConfig } from '@sol/classes/enrollment';
 import {
     MountainSolApiService,
     type AdditionalInfoPanel,
@@ -158,14 +149,25 @@ interface Semester {
                                 </button>
                             } @else {
                                 <div class="copy-from-controls">
-                                    <mat-form-field appearance="outline" class="copy-semester-select">
+                                    <mat-form-field
+                                        appearance="outline"
+                                        class="copy-semester-select"
+                                    >
                                         <mat-label>Copy from</mat-label>
                                         <mat-select
                                             [(ngModel)]="copyFromSemesterId"
                                             name="copyFromSemesterId"
                                         >
-                                            @for (semester of otherSemesters(); track semester.id) {
-                                                <mat-option [value]="semester.id">{{ semester.name }}</mat-option>
+                                            @for (
+                                                semester of otherSemesters();
+                                                track semester.id
+                                            ) {
+                                                <mat-option
+                                                    [value]="semester.id"
+                                                    >{{
+                                                        semester.name
+                                                    }}</mat-option
+                                                >
                                             }
                                         </mat-select>
                                     </mat-form-field>
@@ -173,11 +175,16 @@ interface Semester {
                                         mat-raised-button
                                         color="primary"
                                         type="button"
-                                        [disabled]="!copyFromSemesterId() || copyState().status === 'loading'"
+                                        [disabled]="
+                                            !copyFromSemesterId() ||
+                                            copyState().status === 'loading'
+                                        "
                                         (click)="copyFromSemester()"
                                     >
                                         @if (copyState().status === 'loading') {
-                                            <mat-spinner diameter="18"></mat-spinner>
+                                            <mat-spinner
+                                                diameter="18"
+                                            ></mat-spinner>
                                         } @else {
                                             Import
                                         }
@@ -191,10 +198,14 @@ interface Semester {
                                     </button>
                                 </div>
                                 @if (copyState().status === 'error') {
-                                    <span class="copy-error">{{ copyErrorMessage() }}</span>
+                                    <span class="copy-error">{{
+                                        copyErrorMessage()
+                                    }}</span>
                                 }
                                 @if (copyState().status === 'success') {
-                                    <span class="copy-success">Panel imported successfully</span>
+                                    <span class="copy-success"
+                                        >Panel imported successfully</span
+                                    >
                                 }
                             }
                         </div>
@@ -244,19 +255,33 @@ interface Semester {
                                 <div class="gradient-section">
                                     <label class="field-label">Gradient</label>
                                     <div class="gradient-presets">
-                                        @for (preset of gradientPresets; track preset.name) {
+                                        @for (
+                                            preset of gradientPresets;
+                                            track preset.name
+                                        ) {
                                             <button
                                                 type="button"
                                                 class="gradient-swatch"
-                                                [class.selected]="gradient() === preset.value"
-                                                [style.background]="preset.value"
+                                                [class.selected]="
+                                                    gradient() === preset.value
+                                                "
+                                                [style.background]="
+                                                    preset.value
+                                                "
                                                 [matTooltip]="preset.name"
-                                                (click)="gradient.set(preset.value)"
+                                                (click)="
+                                                    gradient.set(preset.value)
+                                                "
                                             ></button>
                                         }
                                     </div>
-                                    <mat-form-field appearance="outline" class="gradient-input">
-                                        <mat-label>Custom CSS Gradient</mat-label>
+                                    <mat-form-field
+                                        appearance="outline"
+                                        class="gradient-input"
+                                    >
+                                        <mat-label
+                                            >Custom CSS Gradient</mat-label
+                                        >
                                         <input
                                             matInput
                                             [(ngModel)]="gradient"
@@ -272,42 +297,78 @@ interface Semester {
                         <mat-card class="form-section-card">
                             <mat-card-header>
                                 <mat-card-title>Highlight Boxes</mat-card-title>
-                                <mat-card-subtitle>Colored banners for announcements, warnings, or promotions</mat-card-subtitle>
+                                <mat-card-subtitle
+                                    >Colored banners for announcements,
+                                    warnings, or promotions</mat-card-subtitle
+                                >
                             </mat-card-header>
                             <mat-card-content>
-                                @for (box of highlightBoxes(); track box.id; let i = $index) {
+                                @for (
+                                    box of highlightBoxes();
+                                    track box.id;
+                                    let i = $index
+                                ) {
                                     <div class="highlight-box-row">
-                                        <mat-form-field appearance="outline" class="type-select">
+                                        <mat-form-field
+                                            appearance="outline"
+                                            class="type-select"
+                                        >
                                             <mat-label>Type</mat-label>
                                             <mat-select
                                                 [ngModel]="box.type"
-                                                (ngModelChange)="updateHighlightBox(i, 'type', $event)"
+                                                (ngModelChange)="
+                                                    updateHighlightBox(
+                                                        i,
+                                                        'type',
+                                                        $event
+                                                    )
+                                                "
                                                 [name]="'boxType_' + box.id"
                                             >
                                                 <mat-option value="info">
-                                                    <span class="type-indicator info-indicator"></span>
+                                                    <span
+                                                        class="type-indicator info-indicator"
+                                                    ></span>
                                                     Info
                                                 </mat-option>
                                                 <mat-option value="success">
-                                                    <span class="type-indicator success-indicator"></span>
+                                                    <span
+                                                        class="type-indicator success-indicator"
+                                                    ></span>
                                                     Success
                                                 </mat-option>
                                                 <mat-option value="warning">
-                                                    <span class="type-indicator warning-indicator"></span>
+                                                    <span
+                                                        class="type-indicator warning-indicator"
+                                                    ></span>
                                                     Warning
                                                 </mat-option>
                                                 <mat-option value="promotional">
-                                                    <span class="type-indicator promotional-indicator"></span>
+                                                    <span
+                                                        class="type-indicator promotional-indicator"
+                                                    ></span>
                                                     Promotional
                                                 </mat-option>
                                             </mat-select>
                                         </mat-form-field>
-                                        <mat-form-field appearance="outline" class="box-text">
-                                            <mat-label>Text (supports markdown)</mat-label>
+                                        <mat-form-field
+                                            appearance="outline"
+                                            class="box-text"
+                                        >
+                                            <mat-label
+                                                >Text (supports
+                                                markdown)</mat-label
+                                            >
                                             <textarea
                                                 matInput
                                                 [ngModel]="box.text"
-                                                (ngModelChange)="updateHighlightBox(i, 'text', $event)"
+                                                (ngModelChange)="
+                                                    updateHighlightBox(
+                                                        i,
+                                                        'text',
+                                                        $event
+                                                    )
+                                                "
                                                 [name]="'boxText_' + box.id"
                                                 rows="2"
                                             ></textarea>
@@ -338,165 +399,402 @@ interface Semester {
                         <mat-card class="form-section-card">
                             <mat-card-header>
                                 <mat-card-title>Info Cards</mat-card-title>
-                                <mat-card-subtitle>Cards with titles, icons, and content sections</mat-card-subtitle>
+                                <mat-card-subtitle
+                                    >Cards with titles, icons, and content
+                                    sections</mat-card-subtitle
+                                >
                             </mat-card-header>
                             <mat-card-content>
                                 <mat-accordion multi>
-                                    @for (card of infoCards(); track card.id; let cardIdx = $index) {
+                                    @for (
+                                        card of infoCards();
+                                        track card.id;
+                                        let cardIdx = $index
+                                    ) {
                                         <mat-expansion-panel>
                                             <mat-expansion-panel-header>
                                                 <mat-panel-title>
                                                     @if (card.icon) {
-                                                        <span class="card-icon-preview">{{ card.icon }}</span>
+                                                        <span
+                                                            class="card-icon-preview"
+                                                            >{{
+                                                                card.icon
+                                                            }}</span
+                                                        >
                                                     }
-                                                    {{ card.title || 'Untitled Card' }}
+                                                    {{
+                                                        card.title ||
+                                                            'Untitled Card'
+                                                    }}
                                                 </mat-panel-title>
                                                 <mat-panel-description>
-                                                    {{ card.content.length }} content section{{ card.content.length !== 1 ? 's' : '' }}
+                                                    {{ card.content.length }}
+                                                    content section{{
+                                                        card.content.length !==
+                                                        1
+                                                            ? 's'
+                                                            : ''
+                                                    }}
                                                 </mat-panel-description>
                                             </mat-expansion-panel-header>
 
                                             <div class="card-fields">
                                                 <div class="card-header-row">
-                                                    <mat-form-field appearance="outline" class="card-title-field">
-                                                        <mat-label>Card Title</mat-label>
+                                                    <mat-form-field
+                                                        appearance="outline"
+                                                        class="card-title-field"
+                                                    >
+                                                        <mat-label
+                                                            >Card
+                                                            Title</mat-label
+                                                        >
                                                         <input
                                                             matInput
-                                                            [ngModel]="card.title"
-                                                            (ngModelChange)="updateInfoCard(cardIdx, 'title', $event)"
-                                                            [name]="'cardTitle_' + card.id"
+                                                            [ngModel]="
+                                                                card.title
+                                                            "
+                                                            (ngModelChange)="
+                                                                updateInfoCard(
+                                                                    cardIdx,
+                                                                    'title',
+                                                                    $event
+                                                                )
+                                                            "
+                                                            [name]="
+                                                                'cardTitle_' +
+                                                                card.id
+                                                            "
                                                             placeholder="e.g., Schedule & Dates"
                                                         />
                                                     </mat-form-field>
-                                                    <mat-form-field appearance="outline" class="card-icon-field">
-                                                        <mat-label>Icon (emoji)</mat-label>
+                                                    <mat-form-field
+                                                        appearance="outline"
+                                                        class="card-icon-field"
+                                                    >
+                                                        <mat-label
+                                                            >Icon
+                                                            (emoji)</mat-label
+                                                        >
                                                         <input
                                                             matInput
-                                                            [ngModel]="card.icon"
-                                                            (ngModelChange)="updateInfoCard(cardIdx, 'icon', $event)"
-                                                            [name]="'cardIcon_' + card.id"
+                                                            [ngModel]="
+                                                                card.icon
+                                                            "
+                                                            (ngModelChange)="
+                                                                updateInfoCard(
+                                                                    cardIdx,
+                                                                    'icon',
+                                                                    $event
+                                                                )
+                                                            "
+                                                            [name]="
+                                                                'cardIcon_' +
+                                                                card.id
+                                                            "
                                                         />
                                                     </mat-form-field>
                                                 </div>
 
-                                                @for (section of card.content; track section.id; let sectionIdx = $index) {
-                                                    <div class="content-section">
-                                                        <div class="content-section-header">
+                                                @for (
+                                                    section of card.content;
+                                                    track section.id;
+                                                    let sectionIdx = $index
+                                                ) {
+                                                    <div
+                                                        class="content-section"
+                                                    >
+                                                        <div
+                                                            class="content-section-header"
+                                                        >
                                                             <mat-button-toggle-group
-                                                                [ngModel]="section.type"
-                                                                (ngModelChange)="updateContentType(cardIdx, sectionIdx, $event)"
-                                                                [name]="'contentType_' + section.id"
+                                                                [ngModel]="
+                                                                    section.type
+                                                                "
+                                                                (ngModelChange)="
+                                                                    updateContentType(
+                                                                        cardIdx,
+                                                                        sectionIdx,
+                                                                        $event
+                                                                    )
+                                                                "
+                                                                [name]="
+                                                                    'contentType_' +
+                                                                    section.id
+                                                                "
                                                             >
-                                                                <mat-button-toggle value="text">Text</mat-button-toggle>
-                                                                <mat-button-toggle value="list">List</mat-button-toggle>
-                                                                <mat-button-toggle value="grid">Grid</mat-button-toggle>
+                                                                <mat-button-toggle
+                                                                    value="text"
+                                                                    >Text</mat-button-toggle
+                                                                >
+                                                                <mat-button-toggle
+                                                                    value="list"
+                                                                    >List</mat-button-toggle
+                                                                >
+                                                                <mat-button-toggle
+                                                                    value="grid"
+                                                                    >Grid</mat-button-toggle
+                                                                >
                                                             </mat-button-toggle-group>
                                                             <button
                                                                 mat-icon-button
                                                                 color="warn"
                                                                 type="button"
-                                                                (click)="removeContentSection(cardIdx, sectionIdx)"
+                                                                (click)="
+                                                                    removeContentSection(
+                                                                        cardIdx,
+                                                                        sectionIdx
+                                                                    )
+                                                                "
                                                                 matTooltip="Remove content section"
                                                             >
-                                                                <mat-icon>delete</mat-icon>
+                                                                <mat-icon
+                                                                    >delete</mat-icon
+                                                                >
                                                             </button>
                                                         </div>
 
-                                                        @if (section.type === 'text') {
-                                                            <mat-form-field appearance="outline">
-                                                                <mat-label>Text (supports markdown)</mat-label>
+                                                        @if (
+                                                            section.type ===
+                                                            'text'
+                                                        ) {
+                                                            <mat-form-field
+                                                                appearance="outline"
+                                                            >
+                                                                <mat-label
+                                                                    >Text
+                                                                    (supports
+                                                                    markdown)</mat-label
+                                                                >
                                                                 <textarea
                                                                     matInput
-                                                                    [ngModel]="section.text"
-                                                                    (ngModelChange)="updateContentText(cardIdx, sectionIdx, $event)"
-                                                                    [name]="'contentText_' + section.id"
+                                                                    [ngModel]="
+                                                                        section.text
+                                                                    "
+                                                                    (ngModelChange)="
+                                                                        updateContentText(
+                                                                            cardIdx,
+                                                                            sectionIdx,
+                                                                            $event
+                                                                        )
+                                                                    "
+                                                                    [name]="
+                                                                        'contentText_' +
+                                                                        section.id
+                                                                    "
                                                                     rows="3"
                                                                 ></textarea>
                                                             </mat-form-field>
                                                         }
 
-                                                        @if (section.type === 'list') {
-                                                            <div class="list-items">
-                                                                @for (item of section.items; track item.id; let itemIdx = $index) {
-                                                                    <div class="list-item-row">
-                                                                        <mat-form-field appearance="outline">
-                                                                            <mat-label>Item {{ itemIdx + 1 }}</mat-label>
+                                                        @if (
+                                                            section.type ===
+                                                            'list'
+                                                        ) {
+                                                            <div
+                                                                class="list-items"
+                                                            >
+                                                                @for (
+                                                                    item of section.items;
+                                                                    track item.id;
+                                                                    let itemIdx = $index
+                                                                ) {
+                                                                    <div
+                                                                        class="list-item-row"
+                                                                    >
+                                                                        <mat-form-field
+                                                                            appearance="outline"
+                                                                        >
+                                                                            <mat-label
+                                                                                >Item
+                                                                                {{
+                                                                                    itemIdx +
+                                                                                        1
+                                                                                }}</mat-label
+                                                                            >
                                                                             <input
                                                                                 matInput
-                                                                                [ngModel]="item.value"
-                                                                                (ngModelChange)="updateListItem(cardIdx, sectionIdx, itemIdx, $event)"
-                                                                                [name]="'listItem_' + item.id"
+                                                                                [ngModel]="
+                                                                                    item.value
+                                                                                "
+                                                                                (ngModelChange)="
+                                                                                    updateListItem(
+                                                                                        cardIdx,
+                                                                                        sectionIdx,
+                                                                                        itemIdx,
+                                                                                        $event
+                                                                                    )
+                                                                                "
+                                                                                [name]="
+                                                                                    'listItem_' +
+                                                                                    item.id
+                                                                                "
                                                                             />
                                                                         </mat-form-field>
                                                                         <button
                                                                             mat-icon-button
                                                                             color="warn"
                                                                             type="button"
-                                                                            (click)="removeListItem(cardIdx, sectionIdx, itemIdx)"
+                                                                            (click)="
+                                                                                removeListItem(
+                                                                                    cardIdx,
+                                                                                    sectionIdx,
+                                                                                    itemIdx
+                                                                                )
+                                                                            "
                                                                         >
-                                                                            <mat-icon>close</mat-icon>
+                                                                            <mat-icon
+                                                                                >close</mat-icon
+                                                                            >
                                                                         </button>
                                                                     </div>
                                                                 }
                                                                 <button
                                                                     mat-stroked-button
                                                                     type="button"
-                                                                    (click)="addListItem(cardIdx, sectionIdx)"
+                                                                    (click)="
+                                                                        addListItem(
+                                                                            cardIdx,
+                                                                            sectionIdx
+                                                                        )
+                                                                    "
                                                                 >
-                                                                    <mat-icon>add</mat-icon>
+                                                                    <mat-icon
+                                                                        >add</mat-icon
+                                                                    >
                                                                     Add Item
                                                                 </button>
                                                             </div>
                                                         }
 
-                                                        @if (section.type === 'grid') {
-                                                            <div class="grid-items">
-                                                                @for (gridItem of section.gridItems; track gridItem.id; let gridIdx = $index) {
-                                                                    <div class="grid-item-row">
-                                                                        <mat-form-field appearance="outline" class="grid-label">
-                                                                            <mat-label>Label</mat-label>
+                                                        @if (
+                                                            section.type ===
+                                                            'grid'
+                                                        ) {
+                                                            <div
+                                                                class="grid-items"
+                                                            >
+                                                                @for (
+                                                                    gridItem of section.gridItems;
+                                                                    track gridItem.id;
+                                                                    let gridIdx = $index
+                                                                ) {
+                                                                    <div
+                                                                        class="grid-item-row"
+                                                                    >
+                                                                        <mat-form-field
+                                                                            appearance="outline"
+                                                                            class="grid-label"
+                                                                        >
+                                                                            <mat-label
+                                                                                >Label</mat-label
+                                                                            >
                                                                             <input
                                                                                 matInput
-                                                                                [ngModel]="gridItem.label"
-                                                                                (ngModelChange)="updateGridItem(cardIdx, sectionIdx, gridIdx, 'label', $event)"
-                                                                                [name]="'gridLabel_' + gridItem.id"
+                                                                                [ngModel]="
+                                                                                    gridItem.label
+                                                                                "
+                                                                                (ngModelChange)="
+                                                                                    updateGridItem(
+                                                                                        cardIdx,
+                                                                                        sectionIdx,
+                                                                                        gridIdx,
+                                                                                        'label',
+                                                                                        $event
+                                                                                    )
+                                                                                "
+                                                                                [name]="
+                                                                                    'gridLabel_' +
+                                                                                    gridItem.id
+                                                                                "
                                                                             />
                                                                         </mat-form-field>
-                                                                        <mat-form-field appearance="outline" class="grid-value">
-                                                                            <mat-label>Value</mat-label>
+                                                                        <mat-form-field
+                                                                            appearance="outline"
+                                                                            class="grid-value"
+                                                                        >
+                                                                            <mat-label
+                                                                                >Value</mat-label
+                                                                            >
                                                                             <input
                                                                                 matInput
-                                                                                [ngModel]="gridItem.value"
-                                                                                (ngModelChange)="updateGridItem(cardIdx, sectionIdx, gridIdx, 'value', $event)"
-                                                                                [name]="'gridValue_' + gridItem.id"
+                                                                                [ngModel]="
+                                                                                    gridItem.value
+                                                                                "
+                                                                                (ngModelChange)="
+                                                                                    updateGridItem(
+                                                                                        cardIdx,
+                                                                                        sectionIdx,
+                                                                                        gridIdx,
+                                                                                        'value',
+                                                                                        $event
+                                                                                    )
+                                                                                "
+                                                                                [name]="
+                                                                                    'gridValue_' +
+                                                                                    gridItem.id
+                                                                                "
                                                                             />
                                                                         </mat-form-field>
-                                                                        <mat-form-field appearance="outline" class="grid-desc">
-                                                                            <mat-label>Description</mat-label>
+                                                                        <mat-form-field
+                                                                            appearance="outline"
+                                                                            class="grid-desc"
+                                                                        >
+                                                                            <mat-label
+                                                                                >Description</mat-label
+                                                                            >
                                                                             <input
                                                                                 matInput
-                                                                                [ngModel]="gridItem.description"
-                                                                                (ngModelChange)="updateGridItem(cardIdx, sectionIdx, gridIdx, 'description', $event)"
-                                                                                [name]="'gridDesc_' + gridItem.id"
+                                                                                [ngModel]="
+                                                                                    gridItem.description
+                                                                                "
+                                                                                (ngModelChange)="
+                                                                                    updateGridItem(
+                                                                                        cardIdx,
+                                                                                        sectionIdx,
+                                                                                        gridIdx,
+                                                                                        'description',
+                                                                                        $event
+                                                                                    )
+                                                                                "
+                                                                                [name]="
+                                                                                    'gridDesc_' +
+                                                                                    gridItem.id
+                                                                                "
                                                                             />
                                                                         </mat-form-field>
                                                                         <button
                                                                             mat-icon-button
                                                                             color="warn"
                                                                             type="button"
-                                                                            (click)="removeGridItem(cardIdx, sectionIdx, gridIdx)"
+                                                                            (click)="
+                                                                                removeGridItem(
+                                                                                    cardIdx,
+                                                                                    sectionIdx,
+                                                                                    gridIdx
+                                                                                )
+                                                                            "
                                                                         >
-                                                                            <mat-icon>close</mat-icon>
+                                                                            <mat-icon
+                                                                                >close</mat-icon
+                                                                            >
                                                                         </button>
                                                                     </div>
                                                                 }
                                                                 <button
                                                                     mat-stroked-button
                                                                     type="button"
-                                                                    (click)="addGridItem(cardIdx, sectionIdx)"
+                                                                    (click)="
+                                                                        addGridItem(
+                                                                            cardIdx,
+                                                                            sectionIdx
+                                                                        )
+                                                                    "
                                                                 >
-                                                                    <mat-icon>add</mat-icon>
-                                                                    Add Grid Item
+                                                                    <mat-icon
+                                                                        >add</mat-icon
+                                                                    >
+                                                                    Add Grid
+                                                                    Item
                                                                 </button>
                                                             </div>
                                                         }
@@ -506,7 +804,11 @@ interface Semester {
                                                 <button
                                                     mat-stroked-button
                                                     type="button"
-                                                    (click)="addContentSection(cardIdx)"
+                                                    (click)="
+                                                        addContentSection(
+                                                            cardIdx
+                                                        )
+                                                    "
                                                     class="add-content-btn"
                                                 >
                                                     <mat-icon>add</mat-icon>
@@ -520,9 +822,15 @@ interface Semester {
                                                         mat-button
                                                         color="warn"
                                                         type="button"
-                                                        (click)="removeInfoCard(cardIdx)"
+                                                        (click)="
+                                                            removeInfoCard(
+                                                                cardIdx
+                                                            )
+                                                        "
                                                     >
-                                                        <mat-icon>delete</mat-icon>
+                                                        <mat-icon
+                                                            >delete</mat-icon
+                                                        >
                                                         Remove Card
                                                     </button>
                                                 </div>
@@ -585,11 +893,15 @@ interface Semester {
                         <div class="preview-wrapper">
                             <div class="preview-label">Preview</div>
                             @if (previewConfig(); as config) {
-                                <sol-info-panel [config]="config"></sol-info-panel>
+                                <sol-info-panel
+                                    [config]="config"
+                                ></sol-info-panel>
                             } @else {
                                 <div class="preview-empty">
                                     <mat-icon>visibility_off</mat-icon>
-                                    <p>Add a title and content to see a preview</p>
+                                    <p>
+                                        Add a title and content to see a preview
+                                    </p>
                                 </div>
                             }
                         </div>
@@ -619,15 +931,20 @@ interface Semester {
                 flex: 1;
             }
 
-            .save-success, .save-error {
+            .save-success,
+            .save-error {
                 display: flex;
                 align-items: center;
                 gap: 4px;
                 font-size: 14px;
             }
 
-            .save-success { color: var(--sol-primary); }
-            .save-error { color: var(--sol-error); }
+            .save-success {
+                color: var(--sol-primary);
+            }
+            .save-error {
+                color: var(--sol-error);
+            }
 
             .form-actions-bar {
                 position: sticky;
@@ -724,7 +1041,6 @@ interface Semester {
                 box-shadow: 0 0 0 2px var(--sol-primary);
             }
 
-
             .highlight-box-row {
                 display: grid;
                 grid-template-columns: 140px 1fr auto;
@@ -756,7 +1072,6 @@ interface Semester {
             .promotional-indicator {
                 background: #ff8a80;
             }
-
 
             mat-accordion {
                 display: flex;
@@ -824,7 +1139,6 @@ interface Semester {
                 padding-top: 0.5rem;
             }
 
-
             .preview-column {
                 position: sticky;
                 top: 1rem;
@@ -856,7 +1170,6 @@ interface Semester {
                 text-align: center;
             }
 
-
             .copy-from-row {
                 display: flex;
                 flex-direction: column;
@@ -874,9 +1187,16 @@ interface Semester {
                 width: 260px;
             }
 
-            .copy-error, .copy-success { font-size: 13px; }
-            .copy-error { color: var(--sol-error); }
-            .copy-success { color: var(--sol-primary); }
+            .copy-error,
+            .copy-success {
+                font-size: 13px;
+            }
+            .copy-error {
+                color: var(--sol-error);
+            }
+            .copy-success {
+                color: var(--sol-primary);
+            }
 
             @media (max-width: 1024px) {
                 .editor-layout {
@@ -998,9 +1318,9 @@ export class InfoPanelEditorComponent {
         params: () => this.#semesterIdFromRoute() ?? '',
         stream: ({ params: semesterId }) => {
             if (!semesterId) return of(null);
-            return this.#api.getSemesterInfoPanel({ semesterId }).pipe(
-                catchError(() => of({ panel: null }))
-            );
+            return this.#api
+                .getSemesterInfoPanel({ semesterId })
+                .pipe(catchError(() => of({ panel: null })));
         },
     });
 
@@ -1071,7 +1391,8 @@ export class InfoPanelEditorComponent {
                             if (result.success) {
                                 this.saveState.set({ status: 'success' });
                                 setTimeout(
-                                    () => this.saveState.set({ status: 'idle' }),
+                                    () =>
+                                        this.saveState.set({ status: 'idle' }),
                                     3000
                                 );
                             } else {
@@ -1085,7 +1406,8 @@ export class InfoPanelEditorComponent {
                             this.saveState.set({
                                 status: 'error',
                                 message:
-                                    err?.message ?? 'An unexpected error occurred',
+                                    err?.message ??
+                                    'An unexpected error occurred',
                             });
                             return of(null);
                         })
@@ -1287,11 +1609,7 @@ export class InfoPanelEditorComponent {
         this.infoCards.set(cards);
     }
 
-    updateContentText(
-        cardIndex: number,
-        sectionIndex: number,
-        text: string
-    ) {
+    updateContentText(cardIndex: number, sectionIndex: number, text: string) {
         const cards = [...this.infoCards()];
         const card = { ...cards[cardIndex] };
         const content = [...card.content];
@@ -1317,11 +1635,7 @@ export class InfoPanelEditorComponent {
         this.infoCards.set(cards);
     }
 
-    removeListItem(
-        cardIndex: number,
-        sectionIndex: number,
-        itemIndex: number
-    ) {
+    removeListItem(cardIndex: number, sectionIndex: number, itemIndex: number) {
         const cards = [...this.infoCards()];
         const card = { ...cards[cardIndex] };
         const content = [...card.content];
@@ -1375,11 +1689,7 @@ export class InfoPanelEditorComponent {
         this.infoCards.set(cards);
     }
 
-    removeGridItem(
-        cardIndex: number,
-        sectionIndex: number,
-        gridIndex: number
-    ) {
+    removeGridItem(cardIndex: number, sectionIndex: number, gridIndex: number) {
         const cards = [...this.infoCards()];
         const card = { ...cards[cardIndex] };
         const content = [...card.content];

--- a/libs/angular/classes/class-management/src/lib/components/weekday-selector/weekday-selector.component.ts
+++ b/libs/angular/classes/class-management/src/lib/components/weekday-selector/weekday-selector.component.ts
@@ -103,8 +103,12 @@ export class WeekdaySelectorComponent implements ControlValueAccessor {
 
     readonly weekdayOptions = WEEKDAY_OPTIONS;
 
-    #onChange: (value: string[]) => void = () => {};
-    #onTouched: () => void = () => {};
+    #onChange: (value: string[]) => void = () => {
+        // Default no-op, will be replaced by registerOnChange
+    };
+    #onTouched: () => void = () => {
+        // Default no-op, will be replaced by registerOnTouched
+    };
 
     readonly formattedDisplay = computed(() => {
         const selected = this.selectedDays();

--- a/libs/angular/classes/class-management/src/lib/services/class-form.service.ts
+++ b/libs/angular/classes/class-management/src/lib/services/class-form.service.ts
@@ -7,7 +7,10 @@ import {
     UploadClassImageRequest,
 } from '@sol/angular/firebase/api';
 
-export type ClassFormData = Omit<CreateClassRequest, 'minStudentSize' | 'maxStudentSize'> & {
+export type ClassFormData = Omit<
+    CreateClassRequest,
+    'minStudentSize' | 'maxStudentSize'
+> & {
     minStudentSize: number;
     maxStudentSize: number;
     pausedForEnrollment: boolean;
@@ -32,7 +35,9 @@ export class ClassFormService {
     readonly #api = inject(MountainSolApiService);
 
     uploadImage(data: ImageUploadData): Observable<ImageUploadResult> {
-        const request: Omit<UploadClassImageRequest, 'imageBase64'> & { imageBase64?: string } = {
+        const request: Omit<UploadClassImageRequest, 'imageBase64'> & {
+            imageBase64?: string;
+        } = {
             semesterId: data.semesterId,
             classId: data.classId,
             contentType: data.file.type,
@@ -91,7 +96,10 @@ export class ClassFormService {
             map((result) =>
                 result.success
                     ? { success: true as const, classId: result.classId }
-                    : { success: false as const, error: 'Failed to create class' }
+                    : {
+                          success: false as const,
+                          error: 'Failed to create class',
+                      }
             ),
             catchError((err) =>
                 of({
@@ -102,7 +110,10 @@ export class ClassFormService {
         );
     }
 
-    updateClass(classId: string, data: ClassFormData): Observable<SubmitResult> {
+    updateClass(
+        classId: string,
+        data: ClassFormData
+    ): Observable<SubmitResult> {
         const request: UpdateClassRequest = {
             classId,
             semesterId: data.semesterId,
@@ -136,7 +147,10 @@ export class ClassFormService {
             map((result) =>
                 result.success
                     ? { success: true as const, classId }
-                    : { success: false as const, error: 'Failed to update class' }
+                    : {
+                          success: false as const,
+                          error: 'Failed to update class',
+                      }
             ),
             catchError((err) =>
                 of({

--- a/libs/angular/firebase/adapter/jest.config.ts
+++ b/libs/angular/firebase/adapter/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
     displayName: 'firebase-angular-adapter',
     preset: '../../../../jest.preset.js',

--- a/libs/angular/firebase/adapter/package.json
+++ b/libs/angular/firebase/adapter/package.json
@@ -2,7 +2,11 @@
     "name": "firebase-angular-adapter",
     "version": "0.0.1",
     "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.0",
+        "firebase": "^11.3.1",
+        "@angular/fire": "^20.0.1",
+        "@sol/ts/firebase/adapter": "0.0.1",
+        "@angular/core": "^20.3.15"
     },
     "type": "commonjs",
     "main": "./src/index.js",

--- a/libs/angular/request/src/index.ts
+++ b/libs/angular/request/src/index.ts
@@ -15,7 +15,10 @@ export { RequestedOperatorsUtility } from './lib/utilities/requested-operators.u
 export { RequestedUtility } from './lib/utilities/requested.utility';
 export { RequestService } from './lib/services/request.service';
 export { provideRequests } from './lib/store/request.provider';
-export { declareFunction, declareFunctionWithState } from './lib/utilities/declare-function.utility';
+export {
+    declareFunction,
+    declareFunctionWithState,
+} from './lib/utilities/declare-function.utility';
 export const requestStateDirectives = [
     SolLoadedDirective,
     SolLoadingDirective,

--- a/libs/angular/request/src/lib/utilities/declare-function.utility.ts
+++ b/libs/angular/request/src/lib/utilities/declare-function.utility.ts
@@ -23,7 +23,9 @@ import { Requested } from '../models/requested.type';
  * ```
  */
 export function declareFunction<TReq, TRes>(
-    functionsService: { call<T>(name: string, request?: unknown): Observable<Requested<T>> },
+    functionsService: {
+        call<T>(name: string, request?: unknown): Observable<Requested<T>>;
+    },
     name: string
 ): (request: TReq) => Observable<TRes> {
     return (request: TReq) =>
@@ -37,7 +39,9 @@ export function declareFunction<TReq, TRes>(
  * Use this when you need access to loading/error states.
  */
 export function declareFunctionWithState<TReq, TRes>(
-    functionsService: { call<T>(name: string, request?: unknown): Observable<Requested<T>> },
+    functionsService: {
+        call<T>(name: string, request?: unknown): Observable<Requested<T>>;
+    },
     name: string
 ): (request: TReq) => Observable<Requested<TRes>> {
     return (request: TReq) => functionsService.call<TRes>(name, request);

--- a/libs/firebase/classes/class-enrollment-repository/src/lib/services/class-enrollment-repository.ts
+++ b/libs/firebase/classes/class-enrollment-repository/src/lib/services/class-enrollment-repository.ts
@@ -61,9 +61,10 @@ export class ClassEnrollmentRepository {
             .where('originalEnrollmentId', '==', originalEnrollmentId)
             .where('status', '==', 'enrolled')
             .get();
-        return snapshot.docs.map(
-            (doc) => ({ ...(doc.data() as ClassEnrollmentDbo), id: doc.id })
-        );
+        return snapshot.docs.map((doc) => ({
+            ...(doc.data() as ClassEnrollmentDbo),
+            id: doc.id,
+        }));
     }
 
     static async updateStatus(

--- a/libs/firebase/functions-api/src/lib/services/functions.service.ts
+++ b/libs/firebase/functions-api/src/lib/services/functions.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 import {
     Requested,
     RequestedOperatorsUtility,
@@ -7,7 +7,14 @@ import {
 } from '@sol/angular/request';
 import { catchError, from, map, Observable, of, startWith } from 'rxjs';
 import { FIRE_FUNCTIONS } from '@sol/angular/firebase/adapter';
-import { environment } from 'apps/enrollment-portal/src/environments/environment';
+
+export const USE_REMOTE_FUNCTIONS = new InjectionToken<boolean>(
+    'USE_REMOTE_FUNCTIONS',
+    {
+        providedIn: 'root',
+        factory: () => false,
+    }
+);
 
 @Injectable({
     providedIn: 'root',
@@ -15,12 +22,13 @@ import { environment } from 'apps/enrollment-portal/src/environments/environment
 export class FirebaseFunctionsService {
     private readonly fns = inject(FIRE_FUNCTIONS);
     private readonly http = inject(HttpClient);
+    private readonly useRemoteFunctions = inject(USE_REMOTE_FUNCTIONS);
 
     public call<T>(
         resourcePath: string,
         request?: unknown
     ): Observable<Requested<T>> {
-        if (environment.remoteFunctions) {
+        if (this.useRemoteFunctions) {
             // Production: use Firebase SDK
             const fn = this.fns.httpsCallable(resourcePath);
             return from(fn(request)).pipe(

--- a/libs/firebase/functions/src/lib/utilities/auth.utility.ts
+++ b/libs/firebase/functions/src/lib/utilities/auth.utility.ts
@@ -47,7 +47,10 @@ export class AuthUtility {
         return !!admin;
     }
 
-    public static async validateIsMedicAdmin(req: Request, res: express.Response) {
+    public static async validateIsMedicAdmin(
+        req: Request,
+        res: express.Response
+    ) {
         const decoded = await AuthUtility.validateFirebaseIdToken(req, res);
         if (!decoded) {
             res.status(403).send('Unauthorized');

--- a/libs/firebase/functions/src/lib/utilities/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/utilities/functions.utility.ts
@@ -127,18 +127,12 @@ class FunctionBuilder<SecretNames extends string, StringNames extends string> {
                         } as express.Response,
                         Object.fromEntries(
                             Object.entries(this.secrets)
-                                .map(
-                                    (pair) =>
-                                        pair as [string, SecretParam]
-                                )
+                                .map((pair) => pair as [string, SecretParam])
                                 .map(([key, secret]) => [key, secret.value()])
                         ),
                         Object.fromEntries(
                             Object.entries(this.strings)
-                                .map(
-                                    (pair) =>
-                                        pair as [string, StringParam]
-                                )
+                                .map((pair) => pair as [string, StringParam])
                                 .map(([key, string]) => [key, string.value()])
                         )
                     );

--- a/libs/firebase/payments/.eslintrc.json
+++ b/libs/firebase/payments/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["../../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.js", "*.jsx"],
+            "rules": {}
+        }
+    ]
+}

--- a/libs/firebase/payments/src/lib/email-strategies/medic.email-strategy.ts
+++ b/libs/firebase/payments/src/lib/email-strategies/medic.email-strategy.ts
@@ -38,19 +38,21 @@ export class MedicPaymentEmailStrategy implements PaymentEmailStrategy {
             ? `<strong>${className}</strong>`
             : 'a Mountain SOL Medic class';
 
-        const classDetailsHtml = (classDate || classTime || classLocation)
-            ? `<div class="receipt" style="margin-bottom: 20px;">
+        const classDetailsHtml =
+            classDate || classTime || classLocation
+                ? `<div class="receipt" style="margin-bottom: 20px;">
                             <h2 style="margin-top: 0;">Class Details</h2>
                             ${className ? `<div class="receipt-row"><span class="label">Class:</span><span class="value">${className}</span></div>` : ''}
                             ${classDate ? `<div class="receipt-row"><span class="label">Date:</span><span class="value">${classDate}</span></div>` : ''}
                             ${classTime ? `<div class="receipt-row"><span class="label">Time:</span><span class="value">${classTime}</span></div>` : ''}
                             ${classLocation ? `<div class="receipt-row"><span class="label">Location:</span><span class="value">${classLocation}</span></div>` : ''}
                         </div>`
-            : '';
+                : '';
 
-        const classDetailsText = (classDate || classTime || classLocation)
-            ? `\nCLASS DETAILS\n================\n${className ? `Class: ${className}\n` : ''}${classDate ? `Date: ${classDate}\n` : ''}${classTime ? `Time: ${classTime}\n` : ''}${classLocation ? `Location: ${classLocation}\n` : ''}`
-            : '';
+        const classDetailsText =
+            classDate || classTime || classLocation
+                ? `\nCLASS DETAILS\n================\n${className ? `Class: ${className}\n` : ''}${classDate ? `Date: ${classDate}\n` : ''}${classTime ? `Time: ${classTime}\n` : ''}${classLocation ? `Location: ${classLocation}\n` : ''}`
+                : '';
 
         const html = `
             <!DOCTYPE html>

--- a/libs/firebase/payments/src/lib/factories/medic-payment.factory.ts
+++ b/libs/firebase/payments/src/lib/factories/medic-payment.factory.ts
@@ -16,9 +16,7 @@ export interface MedicClassDetails {
     time?: string;
 }
 
-export class MedicPaymentFactory
-    implements PaymentFactory<BasePaymentRequest>
-{
+export class MedicPaymentFactory implements PaymentFactory<BasePaymentRequest> {
     constructor(private readonly classDetails?: MedicClassDetails) {}
 
     validate(request: BasePaymentRequest): ValidationResult {
@@ -47,9 +45,7 @@ export class MedicPaymentFactory
             : validationFailure(errors);
     }
 
-    createPayment(
-        request: BasePaymentRequest
-    ): Omit<PaymentDbo, 'timestamp'> {
+    createPayment(request: BasePaymentRequest): Omit<PaymentDbo, 'timestamp'> {
         const isVenmo = request.paymentMethodType === 'VenmoAccount';
 
         return {

--- a/libs/firebase/payments/src/lib/handlers/medic-payment.handler.ts
+++ b/libs/firebase/payments/src/lib/handlers/medic-payment.handler.ts
@@ -1,7 +1,10 @@
 import { PaymentFactory, BasePaymentRequest } from '@sol/payments/domain';
 import { Braintree } from '@sol/payments/braintree';
 import { PaymentHandler } from '../payment-handler';
-import { MedicPaymentFactory, MedicClassDetails } from '../factories/medic-payment.factory';
+import {
+    MedicPaymentFactory,
+    MedicClassDetails,
+} from '../factories/medic-payment.factory';
 
 export class MedicPaymentHandler extends PaymentHandler<BasePaymentRequest> {
     readonly #classDetails?: MedicClassDetails;

--- a/libs/react/auth/src/lib/react-auth.tsx
+++ b/libs/react/auth/src/lib/react-auth.tsx
@@ -1,9 +1,6 @@
 import styles from './react-auth.module.css';
 
-/* eslint-disable-next-line */
-export interface ReactAuthProps {}
-
-export function ReactAuth(props: ReactAuthProps) {
+export function ReactAuth() {
     return (
         <div className={styles['container']}>
             <h1>Welcome to ReactAuth!</h1>

--- a/libs/react/request/src/lib/redux-request.tsx
+++ b/libs/react/request/src/lib/redux-request.tsx
@@ -1,9 +1,6 @@
 import styles from './redux-request.module.css';
 
-/* eslint-disable-next-line */
-export interface ReduxRequestProps {}
-
-export function ReduxRequest(props: ReduxRequestProps) {
+export function ReduxRequest() {
     return (
         <div className={styles['container']}>
             <h1>Welcome to ReduxRequest!</h1>

--- a/libs/ts/classes/classes-domain/src/lib/validation/class-validation.suite.ts
+++ b/libs/ts/classes/classes-domain/src/lib/validation/class-validation.suite.ts
@@ -62,9 +62,10 @@ export const classValidationSuite = create(
     }
 );
 
-export function validateClassForPublish(
-    data: ClassValidationData
-): { valid: boolean; errors: string[] } {
+export function validateClassForPublish(data: ClassValidationData): {
+    valid: boolean;
+    errors: string[];
+} {
     const result = classValidationSuite(data);
     const errors = result.getErrors();
 

--- a/libs/ts/firebase/adapter/package.json
+++ b/libs/ts/firebase/adapter/package.json
@@ -2,9 +2,7 @@
     "name": "@sol/ts/firebase/adapter",
     "version": "0.0.1",
     "dependencies": {
-        "tslib": "^2.3.0",
-        "@angular/fire": "^17.0.1",
-        "@angular/core": "17.1.3"
+        "tslib": "^2.3.0"
     },
     "type": "commonjs",
     "main": "./src/index.js",

--- a/libs/ts/firebase/firebase-config/jest.config.ts
+++ b/libs/ts/firebase/firebase-config/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
     displayName: 'firebase-config',
     preset: '../../../../jest.preset.js',

--- a/libs/ts/firebase/firebase-config/package.json
+++ b/libs/ts/firebase/firebase-config/package.json
@@ -2,7 +2,10 @@
     "name": "@sol/ts/firebase/firebase-config",
     "version": "0.0.1",
     "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.0",
+        "firebase": "^11.3.1",
+        "@sol/ts/firebase/adapter": "0.0.1",
+        "@firebase/app": "0.13.1"
     },
     "type": "commonjs",
     "main": "./src/index.js",

--- a/libs/ts/payments/domain/.eslintrc.json
+++ b/libs/ts/payments/domain/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["../../../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.js", "*.jsx"],
+            "rules": {}
+        }
+    ]
+}

--- a/libs/ts/payments/domain/src/lib/payment-result.ts
+++ b/libs/ts/payments/domain/src/lib/payment-result.ts
@@ -1,3 +1,8 @@
 export type PaymentResult =
-    | { success: true; paymentId: string; transactionId: string; amount: number }
+    | {
+          success: true;
+          paymentId: string;
+          transactionId: string;
+          amount: number;
+      }
     | { success: false; errors: string[]; message: string };

--- a/nx.json
+++ b/nx.json
@@ -94,13 +94,8 @@
     "$schema": "./node_modules/nx/schemas/nx-schema.json",
     "targetDefaults": {
         "build": {
-            "dependsOn": [
-                "^build"
-            ],
-            "inputs": [
-                "production",
-                "^production"
-            ],
+            "dependsOn": ["^build"],
+            "inputs": ["production", "^production"],
             "options": {
                 "allowedCommonJsDependencies": [
                     "braintree-web",
@@ -127,41 +122,23 @@
             }
         },
         "@nx/eslint:lint": {
-            "inputs": [
-                "default",
-                "{workspaceRoot}/.eslintrc.json"
-            ],
+            "inputs": ["default", "{workspaceRoot}/.eslintrc.json"],
             "cache": true
         },
         "@nx/angular:ng-packagr-lite": {
             "cache": true,
-            "dependsOn": [
-                "^build"
-            ],
-            "inputs": [
-                "production",
-                "^production"
-            ]
+            "dependsOn": ["^build"],
+            "inputs": ["production", "^production"]
         },
         "@nx/js:tsc": {
             "cache": true,
-            "dependsOn": [
-                "^build"
-            ],
-            "inputs": [
-                "production",
-                "^production"
-            ]
+            "dependsOn": ["^build"],
+            "inputs": ["production", "^production"]
         }
     },
     "namedInputs": {
-        "default": [
-            "{projectRoot}/**/*",
-            "sharedGlobals"
-        ],
-        "sharedGlobals": [
-            "{workspaceRoot}/babel.config.json"
-        ],
+        "default": ["{projectRoot}/**/*", "sharedGlobals"],
+        "sharedGlobals": ["{workspaceRoot}/babel.config.json"],
         "production": [
             "default",
             "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",


### PR DESCRIPTION
## Summary

The husky pre-commit hook had been silently broken (`.husky/_/husky.sh` was missing), so a backlog of ~282 lint errors had accumulated on `main`. Now that husky has been re-initialized, no new commit can land without first clearing the backlog. This PR does that.

After this PR: `npx nx run-many --target=lint --all` returns **0 errors** across all 51 projects, and `git commit` passes the hook without `--no-verify`.

## Commits

- **`5e730f4`** — Exclude `.claude/worktrees` from nx project discovery so the local Claude Code worktree doesn't cause duplicate `project.json` collisions.
- **`fa10889`** — The bulk of the cleanup (see breakdown below).
- **`ff95054`** — Trailing `nx format:write` normalization of `nx.json` that the pre-commit hook applied during the previous commit; pure whitespace.

## What was actually wrong (vs. what the cleanup runbook predicted)

| Category | Predicted | Actual | Notes |
|---|---|---|---|
| `prettier/prettier` | — | **213** | Not in the runbook; biggest category, all `--fix`-able |
| `@nx/enforce-module-boundaries` (circular) | ~200 | 108 | Single root cause — see below |
| `@nx/enforce-module-boundaries` (relative) | 6 | 7 | All in `.stories.ts` reaching into `apps/enrollment-portal/.storybook/` |
| `eslint-comments/*` on jest configs | 6 | 6 | Match |
| Storybook + React parser errors | 2 | 6 | Two configs × multiple rules; React `.tsx` parser was also broken |
| `@nx/dependency-checks` | 2 | 2 | Auto-fixed by `nx lint --fix` |
| Empty fn / lifecycle | 4 | 3 | Match |
| `unused-imports/no-unused-imports` | 3 | 2 | Auto-fixed |
| `@typescript-eslint/triple-slash-reference` | — | 1 | New; affects `next-env.d.ts` |

## The big one: cycles weren't an architectural problem

All 108 circular-dep errors shared one root cause:

```
libs/firebase/functions-api/src/lib/services/functions.service.ts:10
import { environment } from 'apps/enrollment-portal/src/environments/environment';
```

A library reaching into the app's environment file just to read one boolean (`environment.remoteFunctions`). Replaced with an `InjectionToken<boolean> USE_REMOTE_FUNCTIONS`, provided in `apps/enrollment-portal/src/main.ts`. That single edit cleared 106 of 108 cycles. The remaining 2 (`enrollment-portal -> angular-admin-{discounts,enrollment-messages} -> enrollment-portal` via storybook fixtures) are now in `ignoredCircularDependencies` — the proper fix (promoting `.storybook/fixtures` to a shared lib) is out of scope here.

No new shared-types library extraction needed.

## Other things worth noting

- **React `*.tsx` parser config was missing at the root.** `plugin:@nx/react` ships as a flat config and doesn't propagate `parserOptions` through legacy `extends`. Added `@typescript-eslint/parser` + `sourceType: 'module'` + `ecmaFeatures.jsx` for `*.tsx` at the root `.eslintrc.json`.
- **`payments-domain` and `firebase-payments` had no `.eslintrc.json`.** With the root's `ignorePatterns: ["**/*"]`, that meant `nx run-many --target=lint --all` failed with "all files ignored" for both. Added minimal configs following the existing template.
- **`apps/student-portal/next-env.d.ts`** is auto-generated by Next.js ("should not be edited"). Disabled `@typescript-eslint/triple-slash-reference` for that one filename instead.
- **Storybook stories**: added a `*.stories.{ts,tsx}` override that disables `@nx/enforce-module-boundaries` so stories can reach into `apps/enrollment-portal/.storybook/` for fixtures/mocks without crossing the lib-to-app boundary check.

## Coordination with `chore/security-upgrade-nextjs-angular-21`

Two jest configs in this PR (`libs/angular/firebase/adapter/jest.config.ts`, `libs/ts/firebase/firebase-config/jest.config.ts`) are also being rewritten in the security upgrade PR (`export default { ... }` → `module.exports = { ... }`). Whichever lands first wins; the loser will need a trivial rebase to re-apply or drop the `/* eslint-disable */` removal on top of the new form.

## Test plan

- [x] `npx nx run-many --target=lint --all` exits 0
- [x] `git commit` passes the husky pre-commit hook (typecheck + format:write + affected:lint) without `--no-verify`
- [x] `npx nx run enrollment-portal:build` still succeeds (verifies Phase C `InjectionToken` swap doesn't break the app)
- [ ] Smoke-test the dev server: `dev` (or `npx nx run enrollment-portal:serve:development`) and confirm calls go through `FirebaseFunctionsService` correctly in both modes (`environment.remoteFunctions: true` and `false`)
- [ ] Storybook still builds: `npx nx run enrollment-portal:storybook` (haven't run; touched `.eslintrc.json` storybook override only — no runtime changes there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)