### PR TITLE
fix: align firebase to v12 and regenerate functions lock in CI

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -101,6 +101,11 @@ jobs:
               if: steps.get_affected.outputs.has_changes == 'true'
               run: npx nx run functions:build
 
+            - name: Regenerate functions package-lock.json
+              if: steps.get_affected.outputs.has_changes == 'true'
+              working-directory: dist/apps/functions
+              run: npm install --package-lock-only
+
             - name: Cache node_modules for deploy
               if: steps.get_affected.outputs.has_changes == 'true'
               uses: actions/cache/save@v4

--- a/libs/angular/firebase/adapter/package.json
+++ b/libs/angular/firebase/adapter/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "dependencies": {
         "tslib": "^2.3.0",
-        "firebase": "^11.3.1",
+        "firebase": "^12.13.0",
         "@angular/fire": "21.0.0-rc.0",
         "@sol/ts/firebase/adapter": "0.0.1",
         "@angular/core": "^21.2.9"

--- a/libs/ts/firebase/firebase-config/package.json
+++ b/libs/ts/firebase/firebase-config/package.json
@@ -3,9 +3,9 @@
     "version": "0.0.1",
     "dependencies": {
         "tslib": "^2.3.0",
-        "firebase": "^11.3.1",
+        "firebase": "^12.13.0",
         "@sol/ts/firebase/adapter": "0.0.1",
-        "@firebase/app": "^0.13.2"
+        "@firebase/app": "^0.14.12"
     },
     "type": "commonjs",
     "main": "./src/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "braintree-web": "^3.124.0",
                 "braintree-web-drop-in": "^1.45.1",
                 "chart.js": "^4.3.2",
-                "firebase": "^11.3.1",
+                "firebase": "^12.13.0",
                 "firebase-admin": "^13.1.0",
                 "firebase-functions": "^7.0.2",
                 "marked": "^18.0.3",
@@ -1301,653 +1301,6 @@
                 "firebase-tools": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/ai": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.12.0.tgz",
-            "integrity": "sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/app-check-interop-types": "0.3.4",
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/analytics": {
-            "version": "0.10.22",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
-            "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/installations": "0.6.22",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/analytics-compat": {
-            "version": "0.2.28",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
-            "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/analytics": "0.10.22",
-                "@firebase/analytics-types": "0.8.4",
-                "@firebase/component": "0.7.3",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/analytics-types": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
-            "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/app": {
-            "version": "0.14.12",
-            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.12.tgz",
-            "integrity": "sha512-FT+HoNp1NdaZ/N26hCwV3WbxS1m6gTn3p2QRBQ3KH7YqyCQqJx0iT7126RgVk68/Rq+9DeL/zCFnHZ0C4u1nLQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "idb": "7.1.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/app-check": {
-            "version": "0.11.3",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.3.tgz",
-            "integrity": "sha512-aJ4DfubWfTO8/2vhEhIAizOoOmiycESTU32e+OUgbWcS/G3PA4Vxlr/9zaiN2wfUG2AptQ7DTvj00tyuFZP5Bg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/app-check-compat": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.3.tgz",
-            "integrity": "sha512-L3AKIRTJxT9b7cDUH3OyV8gWTnmW3vYkwdzRsukWt4kbPBTct12xalnyvHDkm1lKkr+cQq/4uzBx1bOWsQ2ciw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/app-check": "0.11.3",
-                "@firebase/app-check-types": "0.5.4",
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/app-check-interop-types": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
-            "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/app-check-types": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
-            "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/app-compat": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.12.tgz",
-            "integrity": "sha512-Pe513OBerK/CIBxz4/za9atd5MsZtd6DzHz4cmqkvkrcDWhQChAoHBpZ3McuZNuSP8YZiKwfX/J1frR07l15/w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/app": "0.14.12",
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/app-types": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
-            "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/logger": "0.5.1"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/auth": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.1.tgz",
-            "integrity": "sha512-/1nkKY/MicI+I9WWcx6R4NKs77AaW9NQ0IwsFdUBomWrW0/cXEmopfM2dtLm2oI1qG6z6vom3CXZDHJIJXoMuw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@react-native-async-storage/async-storage": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/auth-compat": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.6.tgz",
-            "integrity": "sha512-KDJ/GAf/rt7galOpn3DRb2buFfGkZCsHTryKjXDG0eeRnok4+2B4nnkMOMdjRnPkElmcJv2Ao0vEA6kp5m98PQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/auth": "1.13.1",
-                "@firebase/auth-types": "0.13.1",
-                "@firebase/component": "0.7.3",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/auth-interop-types": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
-            "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/auth-types": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
-            "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "@firebase/app-types": "0.x",
-                "@firebase/util": "1.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/component": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
-            "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/data-connect": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.0.tgz",
-            "integrity": "sha512-ar9sNOJh5poQCSMSVlnVE8eo8+usTD1POWDCv65omkKUvnFMcdXaQ7J/e7WGKqJzcEMgiezSX/TZiKHZkItMbQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/auth-interop-types": "0.2.5",
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/database": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
-            "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/app-check-interop-types": "0.3.4",
-                "@firebase/auth-interop-types": "0.2.5",
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "faye-websocket": "0.11.4",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/database-compat": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
-            "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/database": "1.1.3",
-                "@firebase/database-types": "1.0.20",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/database-types": {
-            "version": "1.0.20",
-            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
-            "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/app-types": "0.9.5",
-                "@firebase/util": "1.15.1"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/firestore": {
-            "version": "4.14.1",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.1.tgz",
-            "integrity": "sha512-PouS0NJZ3NYOZE/tPDvXa8VUeJ10Ll//7jIdFvMYdhQkd/P3O7nlqhyoTmY0h8Xa9hxg+H0j6gxUytJcoZ9YOg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "@firebase/webchannel-wrapper": "1.0.6",
-                "@grpc/grpc-js": "~1.9.0",
-                "@grpc/proto-loader": "^0.7.8",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/firestore-compat": {
-            "version": "0.4.9",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.9.tgz",
-            "integrity": "sha512-NPtBuFr79BbIQJXFWhW4xFC6rBksK8/ewqCTYbbAYfZBDDx0/iHTUj4WpKi5D4d0Pn2Md/3T/e5V9379G5N/Zg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/firestore": "4.14.1",
-                "@firebase/firestore-types": "3.0.4",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/firestore-types": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
-            "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "@firebase/app-types": "0.x",
-                "@firebase/util": "1.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/functions": {
-            "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.4.tgz",
-            "integrity": "sha512-oB5rpm2Emxn2+IS1gRelAeT/5tSZMwM/KhqC5LnJsmTNnS1ZDhD7ZMZNgCI8vchTW6PbaXIwEnpUryGuIQsNbg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/app-check-interop-types": "0.3.4",
-                "@firebase/auth-interop-types": "0.2.5",
-                "@firebase/component": "0.7.3",
-                "@firebase/messaging-interop-types": "0.2.4",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/functions-compat": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.4.tgz",
-            "integrity": "sha512-Be+MwhseVf/eFAZwGrFJGok6S7cmsLrAPK8MgyM8LjM0MewTsx2n01WOOca9jio1UsCZOJ0aVyQobnINcdNuIQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/functions": "0.13.4",
-                "@firebase/functions-types": "0.6.4",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/functions-types": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
-            "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/installations": {
-            "version": "0.6.22",
-            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
-            "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/util": "1.15.1",
-                "idb": "7.1.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/installations-compat": {
-            "version": "0.2.22",
-            "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
-            "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/installations": "0.6.22",
-                "@firebase/installations-types": "0.5.4",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/installations-types": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
-            "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "@firebase/app-types": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/logger": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
-            "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/messaging": {
-            "version": "0.12.26",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.26.tgz",
-            "integrity": "sha512-lHVTO9uLofymHVWkYeUtMddIPcmJvSzVbHRB88W6XKfxbcKF+p3QrfqKhDxremSB4NQjUla1Gwn7d9umSMmt/w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/installations": "0.6.22",
-                "@firebase/messaging-interop-types": "0.2.4",
-                "@firebase/util": "1.15.1",
-                "idb": "7.1.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/messaging-compat": {
-            "version": "0.2.26",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.26.tgz",
-            "integrity": "sha512-fn0XvWOfK4tsDLSipwJUW9Cp6ahWA6z+iJHxZ0pHp9MzMSUNQx85yuxZAuI7gkGXfqs7+DqEDHyyS7jDGswrmQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/messaging": "0.12.26",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/messaging-interop-types": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.4.tgz",
-            "integrity": "sha512-wrzITQq+xw5LtygX7O0fu43/k9ABQ4x5H9/sR5m1SbNnhIRI5xd3+raSNJaJkYC4BUhM9A4ZNSnyR2sjhxnb2Q==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/performance": {
-            "version": "0.7.12",
-            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
-            "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/installations": "0.6.22",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0",
-                "web-vitals": "^4.2.4"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/performance-compat": {
-            "version": "0.2.25",
-            "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
-            "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/performance": "0.7.12",
-                "@firebase/performance-types": "0.2.4",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/performance-types": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
-            "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/remote-config": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.3.tgz",
-            "integrity": "sha512-ggGKAaLy9YNOvpFoQZgm5p5SiFw3ZFtwti08dojnBQmQicpThTxvG5xZMSpCTYMj2o3gM/yK9CVd2w+kZub8YA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/installations": "0.6.22",
-                "@firebase/logger": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/remote-config-compat": {
-            "version": "0.2.24",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.24.tgz",
-            "integrity": "sha512-EWZTt6fJ7YmPHodQNsSxAIDZY2x8P5kRPvXAc5CmzzBm+NyPFhODbfDsNllDXDL8jlzp50bVWjDY+BXepZS9Mg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/logger": "0.5.1",
-                "@firebase/remote-config": "0.8.3",
-                "@firebase/remote-config-types": "0.5.1",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/remote-config-types": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
-            "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/storage": {
-            "version": "0.14.3",
-            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
-            "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/storage-compat": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
-            "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.7.3",
-                "@firebase/storage": "0.14.3",
-                "@firebase/storage-types": "0.8.4",
-                "@firebase/util": "1.15.1",
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@firebase/app-compat": "0.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/storage-types": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
-            "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "@firebase/app-types": "0.x",
-                "@firebase/util": "1.x"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/util": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
-            "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@angular/fire/node_modules/@firebase/webchannel-wrapper": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
-            "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@angular/fire/node_modules/firebase": {
-            "version": "12.13.0",
-            "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.13.0.tgz",
-            "integrity": "sha512-iutR8ejvAqk6qUClnsPz3U3VIjTWp243AX4cD3iifak5t56to1J29xUIQgSDDzaAqKvhshZerzSahwMQj2TlvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/ai": "2.12.0",
-                "@firebase/analytics": "0.10.22",
-                "@firebase/analytics-compat": "0.2.28",
-                "@firebase/app": "0.14.12",
-                "@firebase/app-check": "0.11.3",
-                "@firebase/app-check-compat": "0.4.3",
-                "@firebase/app-compat": "0.5.12",
-                "@firebase/app-types": "0.9.5",
-                "@firebase/auth": "1.13.1",
-                "@firebase/auth-compat": "0.6.6",
-                "@firebase/data-connect": "0.7.0",
-                "@firebase/database": "1.1.3",
-                "@firebase/database-compat": "2.1.4",
-                "@firebase/firestore": "4.14.1",
-                "@firebase/firestore-compat": "0.4.9",
-                "@firebase/functions": "0.13.4",
-                "@firebase/functions-compat": "0.4.4",
-                "@firebase/installations": "0.6.22",
-                "@firebase/installations-compat": "0.2.22",
-                "@firebase/messaging": "0.12.26",
-                "@firebase/messaging-compat": "0.2.26",
-                "@firebase/performance": "0.7.12",
-                "@firebase/performance-compat": "0.2.25",
-                "@firebase/remote-config": "0.8.3",
-                "@firebase/remote-config-compat": "0.2.24",
-                "@firebase/storage": "0.14.3",
-                "@firebase/storage-compat": "0.4.3",
-                "@firebase/util": "1.15.1"
             }
         },
         "node_modules/@angular/forms": {
@@ -5313,19 +4666,19 @@
             "license": "MIT"
         },
         "node_modules/@firebase/ai": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-1.4.1.tgz",
-            "integrity": "sha512-bcusQfA/tHjUjBTnMx6jdoPMpDl3r8K15Z+snHz9wq0Foox0F/V+kNLXucEOHoTL2hTc9l+onZCyBJs2QoIC3g==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.12.0.tgz",
+            "integrity": "sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/app-check-interop-types": "0.3.3",
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/app-check-interop-types": "0.3.4",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app": "0.x",
@@ -5333,15 +4686,15 @@
             }
         },
         "node_modules/@firebase/analytics": {
-            "version": "0.10.17",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.17.tgz",
-            "integrity": "sha512-n5vfBbvzduMou/2cqsnKrIes4auaBjdhg8QNA2ZQZ59QgtO2QiwBaXQZQE4O4sgB0Ds1tvLgUUkY+pwzu6/xEg==",
+            "version": "0.10.22",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+            "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/installations": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -5349,15 +4702,15 @@
             }
         },
         "node_modules/@firebase/analytics-compat": {
-            "version": "0.2.23",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.23.tgz",
-            "integrity": "sha512-3AdO10RN18G5AzREPoFgYhW6vWXr3u+OYQv6pl3CX6Fky8QRk0AHurZlY3Q1xkXO0TDxIsdhO3y65HF7PBOJDw==",
+            "version": "0.2.28",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+            "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/analytics": "0.10.17",
-                "@firebase/analytics-types": "0.8.3",
-                "@firebase/component": "0.6.18",
-                "@firebase/util": "1.12.1",
+                "@firebase/analytics": "0.10.22",
+                "@firebase/analytics-types": "0.8.4",
+                "@firebase/component": "0.7.3",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -5365,135 +4718,138 @@
             }
         },
         "node_modules/@firebase/analytics-types": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
-            "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+            "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/app": {
-            "version": "0.13.2",
-            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.2.tgz",
-            "integrity": "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==",
+            "version": "0.14.12",
+            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.12.tgz",
+            "integrity": "sha512-FT+HoNp1NdaZ/N26hCwV3WbxS1m6gTn3p2QRBQ3KH7YqyCQqJx0iT7126RgVk68/Rq+9DeL/zCFnHZ0C4u1nLQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "idb": "7.1.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/app-check": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.10.1.tgz",
-            "integrity": "sha512-MgNdlms9Qb0oSny87pwpjKush9qUwCJhfmTJHDfrcKo4neLGiSeVE4qJkzP7EQTIUFKp84pbTxobSAXkiuQVYQ==",
+            "version": "0.11.3",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.3.tgz",
+            "integrity": "sha512-aJ4DfubWfTO8/2vhEhIAizOoOmiycESTU32e+OUgbWcS/G3PA4Vxlr/9zaiN2wfUG2AptQ7DTvj00tyuFZP5Bg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app": "0.x"
             }
         },
         "node_modules/@firebase/app-check-compat": {
-            "version": "0.3.26",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.26.tgz",
-            "integrity": "sha512-PkX+XJMLDea6nmnopzFKlr+s2LMQGqdyT2DHdbx1v1dPSqOol2YzgpgymmhC67vitXVpNvS3m/AiWQWWhhRRPQ==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.3.tgz",
+            "integrity": "sha512-L3AKIRTJxT9b7cDUH3OyV8gWTnmW3vYkwdzRsukWt4kbPBTct12xalnyvHDkm1lKkr+cQq/4uzBx1bOWsQ2ciw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/app-check": "0.10.1",
-                "@firebase/app-check-types": "0.5.3",
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/app-check": "0.11.3",
+                "@firebase/app-check-types": "0.5.4",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/app-check-interop-types": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
-            "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+            "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/app-check-types": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
-            "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+            "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/app-compat": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.2.tgz",
-            "integrity": "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==",
+            "version": "0.5.12",
+            "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.12.tgz",
+            "integrity": "sha512-Pe513OBerK/CIBxz4/za9atd5MsZtd6DzHz4cmqkvkrcDWhQChAoHBpZ3McuZNuSP8YZiKwfX/J1frR07l15/w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/app": "0.13.2",
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/app": "0.14.12",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/app-types": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-            "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@firebase/auth-compat": {
-            "version": "0.5.28",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.28.tgz",
-            "integrity": "sha512-HpMSo/cc6Y8IX7bkRIaPPqT//Jt83iWy5rmDWeThXQCAImstkdNo3giFLORJwrZw2ptiGkOij64EH1ztNJzc7Q==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+            "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/auth": "1.10.8",
-                "@firebase/auth-types": "0.13.0",
-                "@firebase/component": "0.6.18",
-                "@firebase/util": "1.12.1",
+                "@firebase/logger": "0.5.1"
+            }
+        },
+        "node_modules/@firebase/auth-compat": {
+            "version": "0.6.6",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.6.tgz",
+            "integrity": "sha512-KDJ/GAf/rt7galOpn3DRb2buFfGkZCsHTryKjXDG0eeRnok4+2B4nnkMOMdjRnPkElmcJv2Ao0vEA6kp5m98PQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/auth": "1.13.1",
+                "@firebase/auth-types": "0.13.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/auth-compat/node_modules/@firebase/auth": {
-            "version": "1.10.8",
-            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.8.tgz",
-            "integrity": "sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.1.tgz",
+            "integrity": "sha512-/1nkKY/MicI+I9WWcx6R4NKs77AaW9NQ0IwsFdUBomWrW0/cXEmopfM2dtLm2oI1qG6z6vom3CXZDHJIJXoMuw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app": "0.x",
-                "@react-native-async-storage/async-storage": "^1.18.1"
+                "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
             },
             "peerDependenciesMeta": {
                 "@react-native-async-storage/async-storage": {
@@ -5502,15 +4858,15 @@
             }
         },
         "node_modules/@firebase/auth-interop-types": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
-            "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+            "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/auth-types": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
-            "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+            "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@firebase/app-types": "0.x",
@@ -5518,28 +4874,28 @@
             }
         },
         "node_modules/@firebase/component": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
-            "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+            "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/util": "1.12.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/data-connect": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.10.tgz",
-            "integrity": "sha512-VMVk7zxIkgwlVQIWHOKFahmleIjiVFwFOjmakXPd/LDgaB/5vzwsB5DWIYo+3KhGxWpidQlR8geCIn39YflJIQ==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.0.tgz",
+            "integrity": "sha512-ar9sNOJh5poQCSMSVlnVE8eo8+usTD1POWDCv65omkKUvnFMcdXaQ7J/e7WGKqJzcEMgiezSX/TZiKHZkItMbQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/auth-interop-types": "0.2.4",
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/auth-interop-types": "0.2.5",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -5547,94 +4903,94 @@
             }
         },
         "node_modules/@firebase/database": {
-            "version": "1.0.20",
-            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.20.tgz",
-            "integrity": "sha512-H9Rpj1pQ1yc9+4HQOotFGLxqAXwOzCHsRSRjcQFNOr8lhUt6LeYjf0NSRL04sc4X0dWe8DsCvYKxMYvFG/iOJw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+            "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/app-check-interop-types": "0.3.3",
-                "@firebase/auth-interop-types": "0.2.4",
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/app-check-interop-types": "0.3.4",
+                "@firebase/auth-interop-types": "0.2.5",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "faye-websocket": "0.11.4",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/database-compat": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.11.tgz",
-            "integrity": "sha512-itEsHARSsYS95+udF/TtIzNeQ0Uhx4uIna0sk4E0wQJBUnLc/G1X6D7oRljoOuwwCezRLGvWBRyNrugv/esOEw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+            "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/database": "1.0.20",
-                "@firebase/database-types": "1.0.15",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/database": "1.1.3",
+                "@firebase/database-types": "1.0.20",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/database-types": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.15.tgz",
-            "integrity": "sha512-XWHJ0VUJ0k2E9HDMlKxlgy/ZuTa9EvHCGLjaKSUvrQnwhgZuRU5N3yX6SZ+ftf2hTzZmfRkv+b3QRvGg40bKNw==",
+            "version": "1.0.20",
+            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+            "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/app-types": "0.9.3",
-                "@firebase/util": "1.12.1"
+                "@firebase/app-types": "0.9.5",
+                "@firebase/util": "1.15.1"
             }
         },
         "node_modules/@firebase/firestore": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.8.0.tgz",
-            "integrity": "sha512-QSRk+Q1/CaabKyqn3C32KSFiOdZpSqI9rpLK5BHPcooElumOBooPFa6YkDdiT+/KhJtel36LdAacha9BptMj2A==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.1.tgz",
+            "integrity": "sha512-PouS0NJZ3NYOZE/tPDvXa8VUeJ10Ll//7jIdFvMYdhQkd/P3O7nlqhyoTmY0h8Xa9hxg+H0j6gxUytJcoZ9YOg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
-                "@firebase/webchannel-wrapper": "1.0.3",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "@firebase/webchannel-wrapper": "1.0.6",
                 "@grpc/grpc-js": "~1.9.0",
                 "@grpc/proto-loader": "^0.7.8",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app": "0.x"
             }
         },
         "node_modules/@firebase/firestore-compat": {
-            "version": "0.3.53",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.53.tgz",
-            "integrity": "sha512-qI3yZL8ljwAYWrTousWYbemay2YZa+udLWugjdjju2KODWtLG94DfO4NALJgPLv8CVGcDHNFXoyQexdRA0Cz8Q==",
+            "version": "0.4.9",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.9.tgz",
+            "integrity": "sha512-NPtBuFr79BbIQJXFWhW4xFC6rBksK8/ewqCTYbbAYfZBDDx0/iHTUj4WpKi5D4d0Pn2Md/3T/e5V9379G5N/Zg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/firestore": "4.8.0",
-                "@firebase/firestore-types": "3.0.3",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/firestore": "4.14.1",
+                "@firebase/firestore-types": "3.0.4",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/firestore-types": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
-            "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+            "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@firebase/app-types": "0.x",
@@ -5642,58 +4998,58 @@
             }
         },
         "node_modules/@firebase/functions": {
-            "version": "0.12.9",
-            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.9.tgz",
-            "integrity": "sha512-FG95w6vjbUXN84Ehezc2SDjGmGq225UYbHrb/ptkRT7OTuCiQRErOQuyt1jI1tvcDekdNog+anIObihNFz79Lg==",
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.4.tgz",
+            "integrity": "sha512-oB5rpm2Emxn2+IS1gRelAeT/5tSZMwM/KhqC5LnJsmTNnS1ZDhD7ZMZNgCI8vchTW6PbaXIwEnpUryGuIQsNbg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/app-check-interop-types": "0.3.3",
-                "@firebase/auth-interop-types": "0.2.4",
-                "@firebase/component": "0.6.18",
-                "@firebase/messaging-interop-types": "0.2.3",
-                "@firebase/util": "1.12.1",
+                "@firebase/app-check-interop-types": "0.3.4",
+                "@firebase/auth-interop-types": "0.2.5",
+                "@firebase/component": "0.7.3",
+                "@firebase/messaging-interop-types": "0.2.4",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app": "0.x"
             }
         },
         "node_modules/@firebase/functions-compat": {
-            "version": "0.3.26",
-            "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.26.tgz",
-            "integrity": "sha512-A798/6ff5LcG2LTWqaGazbFYnjBW8zc65YfID/en83ALmkhu2b0G8ykvQnLtakbV9ajrMYPn7Yc/XcYsZIUsjA==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.4.tgz",
+            "integrity": "sha512-Be+MwhseVf/eFAZwGrFJGok6S7cmsLrAPK8MgyM8LjM0MewTsx2n01WOOca9jio1UsCZOJ0aVyQobnINcdNuIQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/functions": "0.12.9",
-                "@firebase/functions-types": "0.6.3",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/functions": "0.13.4",
+                "@firebase/functions-types": "0.6.4",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/functions-types": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
-            "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+            "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/installations": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.18.tgz",
-            "integrity": "sha512-NQ86uGAcvO8nBRwVltRL9QQ4Reidc/3whdAasgeWCPIcrhOKDuNpAALa6eCVryLnK14ua2DqekCOX5uC9XbU/A==",
+            "version": "0.6.22",
+            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+            "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/util": "1.15.1",
                 "idb": "7.1.1",
                 "tslib": "^2.1.0"
             },
@@ -5702,15 +5058,15 @@
             }
         },
         "node_modules/@firebase/installations-compat": {
-            "version": "0.2.18",
-            "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.18.tgz",
-            "integrity": "sha512-aLFohRpJO5kKBL/XYL4tN+GdwEB/Q6Vo9eZOM/6Kic7asSUgmSfGPpGUZO1OAaSRGwF4Lqnvi1f/f9VZnKzChw==",
+            "version": "0.2.22",
+            "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+            "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/installations": "0.6.18",
-                "@firebase/installations-types": "0.5.3",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/installations-types": "0.5.4",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -5718,36 +5074,36 @@
             }
         },
         "node_modules/@firebase/installations-types": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
-            "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+            "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@firebase/app-types": "0.x"
             }
         },
         "node_modules/@firebase/logger": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
-            "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+            "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/messaging": {
-            "version": "0.12.22",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.22.tgz",
-            "integrity": "sha512-GJcrPLc+Hu7nk+XQ70Okt3M1u1eRr2ZvpMbzbc54oTPJZySHcX9ccZGVFcsZbSZ6o1uqumm8Oc7OFkD3Rn1/og==",
+            "version": "0.12.26",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.26.tgz",
+            "integrity": "sha512-lHVTO9uLofymHVWkYeUtMddIPcmJvSzVbHRB88W6XKfxbcKF+p3QrfqKhDxremSB4NQjUla1Gwn7d9umSMmt/w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/installations": "0.6.18",
-                "@firebase/messaging-interop-types": "0.2.3",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/messaging-interop-types": "0.2.4",
+                "@firebase/util": "1.15.1",
                 "idb": "7.1.1",
                 "tslib": "^2.1.0"
             },
@@ -5756,14 +5112,14 @@
             }
         },
         "node_modules/@firebase/messaging-compat": {
-            "version": "0.2.22",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.22.tgz",
-            "integrity": "sha512-5ZHtRnj6YO6f/QPa/KU6gryjmX4Kg33Kn4gRpNU6M1K47Gm8kcQwPkX7erRUYEH1mIWptfvjvXMHWoZaWjkU7A==",
+            "version": "0.2.26",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.26.tgz",
+            "integrity": "sha512-fn0XvWOfK4tsDLSipwJUW9Cp6ahWA6z+iJHxZ0pHp9MzMSUNQx85yuxZAuI7gkGXfqs7+DqEDHyyS7jDGswrmQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/messaging": "0.12.22",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/messaging": "0.12.26",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -5771,21 +5127,21 @@
             }
         },
         "node_modules/@firebase/messaging-interop-types": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
-            "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.4.tgz",
+            "integrity": "sha512-wrzITQq+xw5LtygX7O0fu43/k9ABQ4x5H9/sR5m1SbNnhIRI5xd3+raSNJaJkYC4BUhM9A4ZNSnyR2sjhxnb2Q==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/performance": {
-            "version": "0.7.7",
-            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.7.tgz",
-            "integrity": "sha512-JTlTQNZKAd4+Q5sodpw6CN+6NmwbY72av3Lb6wUKTsL7rb3cuBIhQSrslWbVz0SwK3x0ZNcqX24qtRbwKiv+6w==",
+            "version": "0.7.12",
+            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+            "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/installations": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0",
                 "web-vitals": "^4.2.4"
             },
@@ -5794,16 +5150,16 @@
             }
         },
         "node_modules/@firebase/performance-compat": {
-            "version": "0.2.20",
-            "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.20.tgz",
-            "integrity": "sha512-XkFK5NmOKCBuqOKWeRgBUFZZGz9SzdTZp4OqeUg+5nyjapTiZ4XoiiUL8z7mB2q+63rPmBl7msv682J3rcDXIQ==",
+            "version": "0.2.25",
+            "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+            "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/performance": "0.7.7",
-                "@firebase/performance-types": "0.2.3",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/performance": "0.7.12",
+                "@firebase/performance-types": "0.2.4",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -5811,21 +5167,21 @@
             }
         },
         "node_modules/@firebase/performance-types": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
-            "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+            "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/remote-config": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.5.tgz",
-            "integrity": "sha512-fU0c8HY0vrVHwC+zQ/fpXSqHyDMuuuglV94VF6Yonhz8Fg2J+KOowPGANM0SZkLvVOYpTeWp3ZmM+F6NjwWLnw==",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.3.tgz",
+            "integrity": "sha512-ggGKAaLy9YNOvpFoQZgm5p5SiFw3ZFtwti08dojnBQmQicpThTxvG5xZMSpCTYMj2o3gM/yK9CVd2w+kZub8YA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/installations": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -5833,16 +5189,16 @@
             }
         },
         "node_modules/@firebase/remote-config-compat": {
-            "version": "0.2.18",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.18.tgz",
-            "integrity": "sha512-YiETpldhDy7zUrnS8e+3l7cNs0sL7+tVAxvVYU0lu7O+qLHbmdtAxmgY+wJqWdW2c9nDvBFec7QiF58pEUu0qQ==",
+            "version": "0.2.24",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.24.tgz",
+            "integrity": "sha512-EWZTt6fJ7YmPHodQNsSxAIDZY2x8P5kRPvXAc5CmzzBm+NyPFhODbfDsNllDXDL8jlzp50bVWjDY+BXepZS9Mg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/remote-config": "0.6.5",
-                "@firebase/remote-config-types": "0.4.0",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/remote-config": "0.8.3",
+                "@firebase/remote-config-types": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -5850,51 +5206,51 @@
             }
         },
         "node_modules/@firebase/remote-config-types": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
-            "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+            "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/storage": {
-            "version": "0.13.14",
-            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.14.tgz",
-            "integrity": "sha512-xTq5ixxORzx+bfqCpsh+o3fxOsGoDjC1nO0Mq2+KsOcny3l7beyBhP/y1u5T6mgsFQwI1j6oAkbT5cWdDBx87g==",
+            "version": "0.14.3",
+            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+            "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app": "0.x"
             }
         },
         "node_modules/@firebase/storage-compat": {
-            "version": "0.3.24",
-            "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.24.tgz",
-            "integrity": "sha512-XHn2tLniiP7BFKJaPZ0P8YQXKiVJX+bMyE2j2YWjYfaddqiJnROJYqSomwW6L3Y+gZAga35ONXUJQju6MB6SOQ==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+            "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/storage": "0.13.14",
-                "@firebase/storage-types": "0.8.3",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/storage": "0.14.3",
+                "@firebase/storage-types": "0.8.4",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/storage-types": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
-            "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+            "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@firebase/app-types": "0.x",
@@ -5902,22 +5258,22 @@
             }
         },
         "node_modules/@firebase/util": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
-            "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+            "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/webchannel-wrapper": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz",
-            "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+            "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
             "license": "Apache-2.0"
         },
         "node_modules/@fullcalendar/angular": {
@@ -27906,39 +27262,39 @@
             }
         },
         "node_modules/firebase": {
-            "version": "11.10.0",
-            "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.10.0.tgz",
-            "integrity": "sha512-nKBXoDzF0DrXTBQJlZa+sbC5By99ysYU1D6PkMRYknm0nCW7rJly47q492Ht7Ndz5MeYSBuboKuhS1e6mFC03w==",
+            "version": "12.13.0",
+            "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.13.0.tgz",
+            "integrity": "sha512-iutR8ejvAqk6qUClnsPz3U3VIjTWp243AX4cD3iifak5t56to1J29xUIQgSDDzaAqKvhshZerzSahwMQj2TlvA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/ai": "1.4.1",
-                "@firebase/analytics": "0.10.17",
-                "@firebase/analytics-compat": "0.2.23",
-                "@firebase/app": "0.13.2",
-                "@firebase/app-check": "0.10.1",
-                "@firebase/app-check-compat": "0.3.26",
-                "@firebase/app-compat": "0.4.2",
-                "@firebase/app-types": "0.9.3",
-                "@firebase/auth": "1.10.8",
-                "@firebase/auth-compat": "0.5.28",
-                "@firebase/data-connect": "0.3.10",
-                "@firebase/database": "1.0.20",
-                "@firebase/database-compat": "2.0.11",
-                "@firebase/firestore": "4.8.0",
-                "@firebase/firestore-compat": "0.3.53",
-                "@firebase/functions": "0.12.9",
-                "@firebase/functions-compat": "0.3.26",
-                "@firebase/installations": "0.6.18",
-                "@firebase/installations-compat": "0.2.18",
-                "@firebase/messaging": "0.12.22",
-                "@firebase/messaging-compat": "0.2.22",
-                "@firebase/performance": "0.7.7",
-                "@firebase/performance-compat": "0.2.20",
-                "@firebase/remote-config": "0.6.5",
-                "@firebase/remote-config-compat": "0.2.18",
-                "@firebase/storage": "0.13.14",
-                "@firebase/storage-compat": "0.3.24",
-                "@firebase/util": "1.12.1"
+                "@firebase/ai": "2.12.0",
+                "@firebase/analytics": "0.10.22",
+                "@firebase/analytics-compat": "0.2.28",
+                "@firebase/app": "0.14.12",
+                "@firebase/app-check": "0.11.3",
+                "@firebase/app-check-compat": "0.4.3",
+                "@firebase/app-compat": "0.5.12",
+                "@firebase/app-types": "0.9.5",
+                "@firebase/auth": "1.13.1",
+                "@firebase/auth-compat": "0.6.6",
+                "@firebase/data-connect": "0.7.0",
+                "@firebase/database": "1.1.3",
+                "@firebase/database-compat": "2.1.4",
+                "@firebase/firestore": "4.14.1",
+                "@firebase/firestore-compat": "0.4.9",
+                "@firebase/functions": "0.13.4",
+                "@firebase/functions-compat": "0.4.4",
+                "@firebase/installations": "0.6.22",
+                "@firebase/installations-compat": "0.2.22",
+                "@firebase/messaging": "0.12.26",
+                "@firebase/messaging-compat": "0.2.26",
+                "@firebase/performance": "0.7.12",
+                "@firebase/performance-compat": "0.2.25",
+                "@firebase/remote-config": "0.8.3",
+                "@firebase/remote-config-compat": "0.2.24",
+                "@firebase/storage": "0.14.3",
+                "@firebase/storage-compat": "0.4.3",
+                "@firebase/util": "1.15.1"
             }
         },
         "node_modules/firebase-admin": {
@@ -29076,22 +28432,22 @@
             }
         },
         "node_modules/firebase/node_modules/@firebase/auth": {
-            "version": "1.10.8",
-            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.8.tgz",
-            "integrity": "sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.1.tgz",
+            "integrity": "sha512-/1nkKY/MicI+I9WWcx6R4NKs77AaW9NQ0IwsFdUBomWrW0/cXEmopfM2dtLm2oI1qG6z6vom3CXZDHJIJXoMuw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.18",
-                "@firebase/logger": "0.4.4",
-                "@firebase/util": "1.12.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "@firebase/app": "0.x",
-                "@react-native-async-storage/async-storage": "^1.18.1"
+                "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
             },
             "peerDependenciesMeta": {
                 "@react-native-async-storage/async-storage": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "braintree-web": "^3.124.0",
         "braintree-web-drop-in": "^1.45.1",
         "chart.js": "^4.3.2",
-        "firebase": "^11.3.1",
+        "firebase": "^12.13.0",
         "firebase-admin": "^13.1.0",
         "firebase-functions": "^7.0.2",
         "marked": "^18.0.3",


### PR DESCRIPTION
## Summary

Two regressions introduced by #220, surfaced after merge:

### 1. Production runtime — \`No Firebase App '[DEFAULT]'\` on enrollment.mountainsol.org

\`@angular/fire@21.0.0-rc.0\` declares \`firebase: ^12.4.0\` in its own \`dependencies\`, but we still pinned \`firebase: ^11.3.1\` at the root. npm satisfied both by installing a **second copy** of \`firebase\`/\`@firebase/app\` under \`node_modules/@angular/fire/node_modules/\`. Each copy keeps the "default app" registry in module-level state, so:

- \`getSolApp()\` called \`initializeApp(config)\` against firebase@11's registry
- \`@angular/fire\`'s \`defaultFirebaseAppFactory\` called \`getApp()\` against firebase@12's (empty) registry

→ \`FirebaseError: No Firebase App '[DEFAULT]' has been created\` on first page load.

Bumping \`firebase\` (and the \`@firebase/app\` pin in \`libs/ts/firebase/firebase-config\`) to \`^12.13.0\` aligns with what \`@angular/fire 21\` bundles, so npm hoists a single copy. Verified: \`find node_modules -path "*/node_modules/@firebase/app/package.json"\` returns one match, and a production build embeds firebase \`12.13.0\`.

### 2. Functions-deploy CI — \`Missing: ms@2.1.3 from lock file\`

\`@nx/esbuild@22.7.2\` (also bumped in #220) generates a \`dist/apps/functions/package-lock.json\` where transitive deps reachable from prod-only deps (\`express → debug → ms\`) are incorrectly marked \`"devOptional": true\`. Since the generated \`package.json\` has no dev/optional sections, \`npm ci\` flags the lock as out of sync and fails. (Reproducible locally: \`cd dist/apps/functions && npm ci\` → same error as CI.)

Fix: regenerate the lock with \`npm install --package-lock-only\` after the nx build, before the artifact upload — npm's own resolver writes correct flags.

### Why the lock isn't static

The functions \`package.json\` and \`package-lock.json\` aren't in the repo — they're built artifacts produced by nx esbuild's \`generatePackageJson\` so the deployed package stays in sync with what the bundle actually imports. The fix replaces nx's broken lock output with one npm generates from the (correct) package.json.

## Test plan

- [ ] Functions-deploy workflow's "Install dependencies" (\`npm ci\`) step passes
- [ ] Hosting deploy succeeds and https://enrollment.mountainsol.org loads without \`No Firebase App\` console error
- [ ] Sign-in flow works (uses \`getSolAuth\` → firebase/auth in the new v12)
- [ ] Remote-config fetch works (uses \`firebase/remote-config\` in the new v12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)