### PR TITLE
fix: stop firebase v12 "missing data field" errors from draft saves

### DIFF
--- a/libs/angular/classes/class-enrollment/src/lib/components/enrollment-workflow/enrollment-workflow.store.ts
+++ b/libs/angular/classes/class-enrollment/src/lib/components/enrollment-workflow/enrollment-workflow.store.ts
@@ -304,9 +304,11 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
             debounceTime(500),
             filter((enrollment) => enrollment !== initialState.enrollment),
             tap((enrollmentPatch) =>
-                this.functions.call<{
-                    enrollmentPatch: Partial<PaidEnrollment>;
-                }>('updateEnrollmentDraft', enrollmentPatch)
+                this.functions
+                    .call<{
+                        enrollmentPatch: Partial<PaidEnrollment>;
+                    }>('updateEnrollmentDraft', enrollmentPatch)
+                    .subscribe()
             )
         );
     });
@@ -507,7 +509,7 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
                     addendumError: undefined,
                 })
             ),
-            tap(() => this.functions.call('deleteEnrollmentDraft')),
+            tap(() => this.functions.call('deleteEnrollmentDraft').subscribe()),
             switchMap((enrollmentId) =>
                 this.functions
                     .call<{
@@ -620,7 +622,7 @@ export class EnrollmentWorkflowStore extends ComponentStore<State> {
                     wasAddendum ? ['/account/enrollments'] : ['/']
                 );
             }),
-            tap(() => this.functions.call('deleteEnrollmentDraft'))
+            tap(() => this.functions.call('deleteEnrollmentDraft').subscribe())
         );
     });
 }

--- a/libs/firebase/enrollment-functions/update-enrollment-draft/src/lib/update-enrollment-draft.ts
+++ b/libs/firebase/enrollment-functions/update-enrollment-draft/src/lib/update-enrollment-draft.ts
@@ -34,5 +34,5 @@ export const updateEnrollmentDraft = Functions.endpoint.handle<
         await draftDoc.update(enrollmentDraft);
     }
 
-    response.send();
+    response.send({ success: true });
 });

--- a/libs/firebase/functions/src/lib/utilities/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/utilities/functions.utility.ts
@@ -122,7 +122,9 @@ class FunctionBuilder<SecretNames extends string, StringNames extends string> {
                             ...response,
                             status: (code: number) => response.status(code),
                             send: (data: unknown) => {
-                                response.send({ data });
+                                response.send({
+                                    data: data === undefined ? null : data,
+                                });
                             },
                         } as express.Response,
                         Object.fromEntries(


### PR DESCRIPTION
## Summary

The `Response is missing data field` console spam still showing on enrollment.mountainsol.org after #221. Two latent bugs combined with the firebase v11 → v12 client upgrade to surface this:

### 1. Server returned a void body that firebase v12 rejects

`libs/firebase/enrollment-functions/update-enrollment-draft/src/lib/update-enrollment-draft.ts:37` calls `response.send()` with no argument. Our `onRequest` wrapper at `libs/firebase/functions/src/lib/utilities/functions.utility.ts:124-126` turns that into `response.send({ data: undefined })`. `JSON.stringify` drops `undefined` fields, so the wire body is literally `{}`.

Firebase v11 client tolerated this. Firebase v12 client (`@firebase/functions/dist/index.cjs.js:653`) strictly requires either `data` or `result` to be defined and throws `FunctionsError('internal', 'Response is missing data field.')` otherwise.

### 2. The promise had no subscriber

`enrollment-workflow.store.ts:saveDraft` calls `this.functions.call('updateEnrollmentDraft', enrollmentPatch)` inside a `tap()`. `tap` discards the return value, so the observable from `.call()` was created (and its inner `fn(request)` already fires the HTTP request) but never subscribed. When the v12 client rejected the promise, no `.then` handler was attached, NgZone caught it as an unhandled rejection, and Angular's `ErrorHandler.handleError` logged it — once per keystroke in the enrollment form, debounced.

The two `deleteEnrollmentDraft` taps in the same store had the same fire-and-forget shape — those didn't surface the error because `deleteEnrollmentDraft` returns `{ success: true }`, but they were still unhandled-rejection liabilities for any non-200 response.

## Fixes

1. **Wrapper default** — `functions.utility.ts` now maps `data === undefined` to `null`, so any handler that legitimately wants to return void still produces a valid wire body `{"data":null}`. Defensive blanket fix against the same class of bug anywhere else.
2. **Explicit `updateEnrollmentDraft` response** — `response.send({ success: true })` so the handler's intent is clear.
3. **Subscribe the fire-and-forget calls** — `saveDraft` and both `deleteEnrollmentDraft` taps now call `.subscribe()` inline. `FirebaseFunctionsService.call`'s internal `catchError` converts errors to `RequestState.Error` before they escape, so a failed draft persist still doesn't break the outer enrollment workflow — it gets swallowed, matching the prior intent. The promise just has a real consumer now.

## Test plan

- [ ] On enrollment.mountainsol.org, edit fields in the enrollment form and confirm no `Response is missing data field` console errors fire on keystrokes.
- [ ] Confirm draft persistence still works — refresh the page mid-form and the partial draft loads back.
- [ ] Trigger an addendum (`initAddendum`) and a successful enroll completion — both call `deleteEnrollmentDraft`, neither should produce console errors and the flow should continue normally even if that call fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)