### PR TITLE
fix: stop adminEnrollments 500 on legacy classIds-only enrollments

### DIFF
--- a/apps/functions-integration-tests/src/tests/admin-enrollments.spec.ts
+++ b/apps/functions-integration-tests/src/tests/admin-enrollments.spec.ts
@@ -186,6 +186,39 @@ describe('Admin Enrollments', () => {
             expect(enrollment?.classNames).toHaveLength(2);
         });
 
+        // Regression: legacy records store the deprecated `classIds` array and
+        // no `classes` field. The repository still sets a `classes` key (value
+        // undefined), so a naive `'classes' in enrollment` check returned
+        // undefined and crashed the whole endpoint with a 500.
+        it('should not 500 on a legacy classIds-only enrollment', async () => {
+            await setFirestoreDoc('enrollment', 'legacy-classids', {
+                userId: nonAdminUser.uid,
+                studentName: 'Legacy Student',
+                contactEmail: 'parent@test.com',
+                studentId: 'student-legacy',
+                finalCost: 100,
+                discountIds: [],
+                discounts: [],
+                classIds: ['legacy-class-a', 'legacy-class-b'],
+                additionalOptionIdsByClassId: {},
+                status: 'enrolled',
+                transactionId: 'emulator-mock-txn',
+                timestamp: new FirestoreTimestamp(new Date()),
+            });
+
+            const result = await callFunction<void, SemesterEnrollment[]>({
+                functionName: 'adminEnrollments',
+                idToken: adminUser.idToken,
+            });
+
+            expect(result.status).toBe(200);
+            const enrollment = findEnrollment(result.data, 'legacy-classids');
+            expect(enrollment?.classNames).toEqual([
+                'legacy-class-a',
+                'legacy-class-b',
+            ]);
+        });
+
         it('should fall back to the class id when a class is missing', async () => {
             await setFirestoreDoc(
                 'enrollment',

--- a/libs/firebase/enrollment-functions/admin-enrollments/src/lib/admin-enrollments.ts
+++ b/libs/firebase/enrollment-functions/admin-enrollments/src/lib/admin-enrollments.ts
@@ -24,9 +24,17 @@ export const adminEnrollments = Functions.endpoint
 function classRefsOf(
     enrollment: SemesterEnrollment
 ): Array<{ id: string; semesterId: string }> {
-    return 'classes' in enrollment
-        ? enrollment.classes
-        : enrollment.classIds.map((id) => ({ id, semesterId: '' }));
+    // The repository always sets a `classes` key (value undefined for legacy
+    // records), so check the value rather than key presence, and fall back to
+    // the deprecated `classIds` array.
+    const classes = (
+        enrollment as { classes?: Array<{ id: string; semesterId: string }> }
+    ).classes;
+    if (classes?.length) {
+        return classes;
+    }
+    const classIds = (enrollment as { classIds?: Array<string> }).classIds;
+    return (classIds ?? []).map((id) => ({ id, semesterId: '' }));
 }
 
 /**


### PR DESCRIPTION
## Production incident

`adminEnrollments` (the admin Enrollments page) was returning **500** in production. Confirmed from Cloud Run logs:

```
TypeError: classRefsOf is not a function or its return value is not iterable
    at resolveClassNames (file:///workspace/main.js:3305:23)
```

## Root cause

`classRefsOf` (added in #224) chose between the `classes` and deprecated `classIds` shapes with `'classes' in enrollment`. But `ClassEnrollmentRepository.getCurrentSemesterEnrollments` always maps `classes: dbo.classes` — so the **key is always present**, with value `undefined` for legacy `classIds`-only records. `classRefsOf` then returned `undefined`, and `for (const ref of classRefsOf(...))` threw, crashing the entire endpoint (one legacy record breaks the whole list).

The emulator tests didn't catch it because every seeded enrollment used the `classes` shape.

## Fix

Check the **value**, not key presence: use `classes` when it's a non-empty array, otherwise fall back to `classIds`, otherwise an empty array. No record shape can crash the endpoint now.

## Tests

Added a regression test seeding a `classIds`-only enrollment. Verified it **reproduces the 500 against the unfixed code** and **passes with the fix**. Full suite: 99/99 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)