### PR TITLE
fix: await role check in Functions.handle (authz race + double-send)

### DIFF
--- a/apps/functions-integration-tests/src/tests/admin-enrollments.spec.ts
+++ b/apps/functions-integration-tests/src/tests/admin-enrollments.spec.ts
@@ -113,12 +113,24 @@ describe('Admin Enrollments', () => {
             expect(result.status).toBe(403);
         });
 
-        // NOTE: A wrong-role (authenticated non-admin) assertion is
-        // intentionally omitted. The shared `Functions.handle` wrapper does
-        // not await the role check before running the handler, so a non-admin
-        // request races between a 403 and a 200 with data. That non-awaited
-        // role guard is a framework-level concern tracked separately; asserting
-        // on it here is inherently flaky.
+        // Regression: the shared Functions.handle wrapper must await the role
+        // check before running the handler. Otherwise a non-admin races to a
+        // 200 with real enrollment data before the 403 is sent.
+        it('should reject non-admin users without leaking data', async () => {
+            await setFirestoreDoc(
+                'enrollment',
+                'leak-check',
+                makeEnrollmentDoc(nonAdminUser.uid)
+            );
+
+            const result = await callFunction<void, SemesterEnrollment[]>({
+                functionName: 'adminEnrollments',
+                idToken: nonAdminUser.idToken,
+            });
+
+            expect(result.status).toBe(403);
+            expect(result.data).toBeUndefined();
+        });
     });
 
     describe('Class name resolution', () => {

--- a/apps/functions-integration-tests/src/tests/discount-functions.spec.ts
+++ b/apps/functions-integration-tests/src/tests/discount-functions.spec.ts
@@ -25,10 +25,7 @@ describe('Discount Functions', () => {
         await clearAuthEmulator();
         await clearFirestoreEmulator();
 
-        adminUser = await createTestUser(
-            ADMIN_USER.email,
-            ADMIN_USER.password
-        );
+        adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
         nonAdminUser = await createTestUser(
             NON_ADMIN_USER.email,
             NON_ADMIN_USER.password
@@ -54,14 +51,13 @@ describe('Discount Functions', () => {
             expect(result.status).toBe(403);
         });
 
-        // Returns 500 instead of 403 due to missing await in AuthUtility.validateRole
         it('should reject non-admin users', async () => {
             const result = await callFunction<CreateDiscountRequest>({
                 functionName: 'createDiscount',
                 data: AMOUNT_DISCOUNT,
                 idToken: nonAdminUser.idToken,
             });
-            expect([403, 500]).toContain(result.status);
+            expect(result.status).toBe(403);
         });
     });
 

--- a/apps/functions-integration-tests/src/tests/enrollment-message-functions.spec.ts
+++ b/apps/functions-integration-tests/src/tests/enrollment-message-functions.spec.ts
@@ -28,10 +28,7 @@ describe('Enrollment Message Functions', () => {
         await clearAuthEmulator();
         await clearFirestoreEmulator();
 
-        adminUser = await createTestUser(
-            ADMIN_USER.email,
-            ADMIN_USER.password
-        );
+        adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
         nonAdminUser = await createTestUser(
             NON_ADMIN_USER.email,
             NON_ADMIN_USER.password
@@ -157,14 +154,13 @@ describe('Enrollment Message Functions', () => {
             expect(result.status).toBe(403);
         });
 
-        // Returns 500 instead of 403 due to missing await in AuthUtility.validateRole
         it('should reject non-admin users', async () => {
             const result = await callFunction<void>({
                 functionName: 'getEnrollmentMessagesAdmin',
                 idToken: nonAdminUser.idToken,
             });
 
-            expect([403, 500]).toContain(result.status);
+            expect(result.status).toBe(403);
         });
 
         it('should return ALL messages for admin', async () => {
@@ -208,7 +204,6 @@ describe('Enrollment Message Functions', () => {
             expect(result.status).toBe(403);
         });
 
-        // Returns 500 instead of 403 due to missing await in AuthUtility.validateRole
         it('should reject non-admin users', async () => {
             const result = await callFunction<UpdateEnrollmentMessagesRequest>({
                 functionName: 'updateEnrollmentMessages',
@@ -216,7 +211,7 @@ describe('Enrollment Message Functions', () => {
                 idToken: nonAdminUser.idToken,
             });
 
-            expect([403, 500]).toContain(result.status);
+            expect(result.status).toBe(403);
         });
 
         it('should replace all messages atomically', async () => {

--- a/apps/functions-integration-tests/src/tests/revoke-enrollment.spec.ts
+++ b/apps/functions-integration-tests/src/tests/revoke-enrollment.spec.ts
@@ -80,10 +80,7 @@ describe('Revoke Enrollment', () => {
         await clearAuthEmulator();
         await clearFirestoreEmulator();
 
-        adminUser = await createTestUser(
-            ADMIN_USER.email,
-            ADMIN_USER.password
-        );
+        adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
         nonAdminUser = await createTestUser(
             NON_ADMIN_USER.email,
             NON_ADMIN_USER.password
@@ -117,16 +114,13 @@ describe('Revoke Enrollment', () => {
             expect(result.status).toBe(403);
         });
 
-        // Role validation runs without await, so the handler may execute
-        // before the role check rejects. With no matching enrollment doc,
-        // the handler returns 404. Accept any non-200 status.
         it('should reject non-admin users', async () => {
             const result = await callFunction<RevokeEnrollmentRequest>({
                 functionName: 'revokeEnrollment',
                 data: { enrollmentId: 'some-id' },
                 idToken: nonAdminUser.idToken,
             });
-            expect(result.status).not.toBe(200);
+            expect(result.status).toBe(403);
         });
     });
 
@@ -331,9 +325,7 @@ describe('Revoke Enrollment', () => {
                 functionName: 'adminEnrollments',
                 idToken: adminUser.idToken,
             });
-            const enrollment = after.data!.find(
-                (e) => e.id === 'full-via-ids'
-            );
+            const enrollment = after.data!.find((e) => e.id === 'full-via-ids');
             expect(enrollment?.status).toBe('revoked');
         });
     });
@@ -450,9 +442,7 @@ describe('Revoke Enrollment', () => {
             // Should have 2 remaining classes
             const classes = 'classes' in enrollment! ? enrollment!.classes : [];
             expect(classes).toHaveLength(2);
-            const classIds = classes.map(
-                (c: { id: string }) => c.id
-            );
+            const classIds = classes.map((c: { id: string }) => c.id);
             expect(classIds).toContain('class-x');
             expect(classIds).toContain('class-z');
             expect(classIds).not.toContain('class-y');
@@ -470,9 +460,7 @@ describe('Revoke Enrollment', () => {
                 'custom-refund',
                 makeEnrollmentDoc(nonAdminUser.uid, {
                     finalCost: 200,
-                    classes: [
-                        { id: 'custom-class', semesterId: SEMESTER_ID },
-                    ],
+                    classes: [{ id: 'custom-class', semesterId: SEMESTER_ID }],
                 })
             );
 
@@ -685,9 +673,7 @@ describe('Revoke Enrollment', () => {
                 'preview-all',
                 makeEnrollmentDoc(nonAdminUser.uid, {
                     finalCost: 150,
-                    classes: [
-                        { id: 'all-a', semesterId: SEMESTER_ID },
-                    ],
+                    classes: [{ id: 'all-a', semesterId: SEMESTER_ID }],
                 })
             );
 

--- a/libs/firebase/functions/src/lib/utilities/auth.utility.ts
+++ b/libs/firebase/functions/src/lib/utilities/auth.utility.ts
@@ -14,27 +14,25 @@ export class AuthUtility {
         request: Request,
         response: express.Response,
         role: Role
-    ) {
+    ): Promise<void> {
         switch (role) {
-            case Role.Admin:
-                AuthUtility.validateIsAdmin(request, response);
-                break;
             case Role.MedicAdmin:
-                AuthUtility.validateIsMedicAdmin(request, response);
-                break;
+                return AuthUtility.validateIsMedicAdmin(request, response);
+            case Role.Admin:
+            default:
+                return AuthUtility.validateIsAdmin(request, response);
         }
     }
     public static async validateIsAdmin(req: Request, res: express.Response) {
         const decoded = await AuthUtility.validateFirebaseIdToken(req, res);
         if (!decoded) {
-            res.status(403).send('Unauthorized');
+            // validateFirebaseIdToken already sent a 403; sending again throws
+            // ERR_HTTP_HEADERS_SENT.
             return;
-        } else {
-            const isAdmin = await AuthUtility.isAdmin(decoded.uid);
-
-            if (!isAdmin) {
-                res.status(403).send();
-            }
+        }
+        const isAdmin = await AuthUtility.isAdmin(decoded.uid);
+        if (!isAdmin) {
+            res.status(403).send();
         }
     }
 
@@ -53,13 +51,13 @@ export class AuthUtility {
     ) {
         const decoded = await AuthUtility.validateFirebaseIdToken(req, res);
         if (!decoded) {
-            res.status(403).send('Unauthorized');
+            // validateFirebaseIdToken already sent a 403; sending again throws
+            // ERR_HTTP_HEADERS_SENT.
             return;
-        } else {
-            const isMedicAdmin = await AuthUtility.isMedicAdmin(decoded.uid);
-            if (!isMedicAdmin) {
-                res.status(403).send();
-            }
+        }
+        const isMedicAdmin = await AuthUtility.isMedicAdmin(decoded.uid);
+        if (!isMedicAdmin) {
+            res.status(403).send();
         }
     }
 
@@ -106,11 +104,11 @@ export class AuthUtility {
     ): Promise<admin.auth.UserRecord | void> {
         const decoded = await AuthUtility.validateFirebaseIdToken(req, res);
         if (!decoded) {
-            res.status(403).send('Unauthorized');
+            // validateFirebaseIdToken already sent a 403; sending again throws
+            // ERR_HTTP_HEADERS_SENT.
             return;
-        } else {
-            return await admin.auth().getUser(decoded.uid);
         }
+        return await admin.auth().getUser(decoded.uid);
     }
 
     public static async getUser(uid: string) {

--- a/libs/firebase/functions/src/lib/utilities/functions.utility.ts
+++ b/libs/firebase/functions/src/lib/utilities/functions.utility.ts
@@ -113,9 +113,15 @@ class FunctionBuilder<SecretNames extends string, StringNames extends string> {
             },
             async (request, response) => {
                 corsMiddleware(request, response, async () => {
-                    this.roles.forEach((role) => {
-                        AuthUtility.validateRole(request, response, role);
-                    });
+                    // Await each role check before running the handler. A failed
+                    // check sends a 403 (flipping headersSent), so bail out
+                    // rather than letting the handler race ahead and leak data.
+                    for (const role of this.roles) {
+                        await AuthUtility.validateRole(request, response, role);
+                        if (response.headersSent) {
+                            return;
+                        }
+                    }
                     handler(
                         request as Parameters<typeof handler>[0],
                         {


### PR DESCRIPTION
## Problem

The shared `Functions.handle` wrapper ran the request handler **without awaiting** the role check:

```ts
this.roles.forEach((role) => {
    AuthUtility.validateRole(request, response, role); // not awaited
});
handler(...); // runs concurrently with the role check
```

So for a `restrictedToRoles(Role.Admin)` endpoint, an authenticated **non-admin** raced between a 403 and the handler's `200 + data`. Whichever Firestore round-trip finished first won. On a fast handler (or under CI timing) the handler could return admin data before the 403 — a real authorization bypass. This affected every admin endpoint.

It also masked a latent **double-send**: `validateFirebaseIdToken` already sends a 403 on failure, then `validateIsAdmin` / `validateIsMedicAdmin` / `getUserFromRequest` sent a *second* 403, throwing `ERR_HTTP_HEADERS_SENT`. While the role check was fire-and-forget that was a harmless unhandled rejection; once awaited it surfaces as a 500 and the unhandled rejection poisons concurrent requests (intermittent `500`s on unrelated admin calls in CI).

## Fix

- `Functions.handle`: await each role check and bail if a response was already sent (`response.headersSent`), so the handler never runs for an unauthorized caller.
- `AuthUtility.validateRole`: return the validator promise so it can be awaited.
- `validateIsAdmin` / `validateIsMedicAdmin` / `getUserFromRequest`: stop re-sending a 403 that `validateFirebaseIdToken` already sent.

No change to client-observable behavior for the success or unauthenticated paths; the wrong-role path now reliably 403s with no data instead of racing.

## Tests

- Tightened the integration tests that previously *tolerated* the racy `500`/non-200 (`expect([403,500])`, `not.toBe(200)`) to assert a clean **403**.
- Added a no-data-leak regression to `adminEnrollments` (non-admin → 403 and `data` undefined).
- Full suite green and deterministic across repeated runs (100/100).

## Known follow-up (not in this PR)

Eleven handlers using `getUserFromRequest` re-send on the `!user` branch (e.g. `enroll`, `enroll-addendum`, `payment-token`, `roles`, `my-enrolled-students`), which can still throw `ERR_HTTP_HEADERS_SENT` on unauthenticated requests. They have divergent intended semantics (some want 401, some want an empty 200 payload), so they need a separate, deliberate pass rather than a blanket change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)