### PR TITLE
fix: keep Revoke & Refund button label on one line

### DIFF
--- a/libs/angular/admin/enrollments/src/lib/components/enrollments.component.html
+++ b/libs/angular/admin/enrollments/src/lib/components/enrollments.component.html
@@ -99,6 +99,7 @@
                     <button
                         mat-stroked-button
                         color="warn"
+                        style="white-space: nowrap"
                         [disabled]="revoking() === enrollment.id"
                         (click)="confirmRevoke(enrollment)"
                     >


### PR DESCRIPTION
## Problem

In the admin Enrollments table, the **Revoke & Refund** button rendered as a squished oval: the label wrapped onto three lines in the narrow Actions cell, and the Material pill border-radius turned the tall wrapped button into an ellipse.

(The Actions column got tighter once the new Classes column was added in #224.)

## Fix

Add `white-space: nowrap` to the button so the label stays on one line and the button keeps its normal pill shape. The table already scrolls horizontally (`responsiveLayout="scroll"`), so the slightly wider column is fine.

Cosmetic only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)