### PR TITLE
fix: stop handler double-send after getUserFromRequest 403

### DIFF
--- a/apps/functions-integration-tests/src/tests/unauthenticated-handlers.spec.ts
+++ b/apps/functions-integration-tests/src/tests/unauthenticated-handlers.spec.ts
@@ -1,0 +1,32 @@
+import { callFunction } from '../utils';
+
+/**
+ * These handlers authenticate via AuthUtility.getUserFromRequest, which sends a
+ * 403 when there is no valid token. The handlers must NOT send a second
+ * response on the `!user` branch — doing so throws ERR_HTTP_HEADERS_SENT after
+ * the 403 was already sent. This suite guards that every such endpoint cleanly
+ * returns 403 (and never a 200) for an unauthenticated request.
+ */
+describe('Unauthenticated handler rejection', () => {
+    const endpoints = [
+        'enroll',
+        'enrollAddendum',
+        'paymentToken',
+        'roles',
+        'myEnrolledStudents',
+        'getMyStudent',
+        'loadEnrollmentDraft',
+        'deleteEnrollmentDraft',
+        'updateEnrollmentDraft',
+        'doesStudentInfoRequireReview',
+        'getEnrollmentForAddendum',
+    ];
+
+    it.each(endpoints)(
+        '%s should return 403 (not 200) without a token',
+        async (functionName) => {
+            const result = await callFunction({ functionName, data: {} });
+            expect(result.status).toBe(403);
+        }
+    );
+});

--- a/libs/firebase/enrollment-functions/delete-enrollment-draft/src/lib/delete-enrollment-draft.ts
+++ b/libs/firebase/enrollment-functions/delete-enrollment-draft/src/lib/delete-enrollment-draft.ts
@@ -6,7 +6,7 @@ export const deleteEnrollmentDraft = Functions.endpoint.handle(
         const user = await AuthUtility.getUserFromRequest(request, response);
 
         if (!user) {
-            response.status(401).send({ error: 'User not found' });
+            // getUserFromRequest already sent a 403.
             return;
         }
 

--- a/libs/firebase/enrollment-functions/does-student-info-require-review/src/lib/does-student-info-require-review.ts
+++ b/libs/firebase/enrollment-functions/does-student-info-require-review/src/lib/does-student-info-require-review.ts
@@ -1,25 +1,28 @@
-import { _assertUserCanManageStudent, _doesStudentInfoRequireReview, _mapStudentFormToStudentDbEntry } from '@sol/firebase/enrollment-functions/shared';
+import {
+    _assertUserCanManageStudent,
+    _doesStudentInfoRequireReview,
+    _mapStudentFormToStudentDbEntry,
+} from '@sol/firebase/enrollment-functions/shared';
 import { AuthUtility, Functions } from '@sol/firebase/functions';
 
 export const doesStudentInfoRequireReview = Functions.endpoint.handle<{
     studentId: string;
-}>(
-    async (request, response) => {
-        const user = await AuthUtility.getUserFromRequest(request, response);
+}>(async (request, response) => {
+    const user = await AuthUtility.getUserFromRequest(request, response);
 
-        if (!user) {
-            response.status(401).send({ error: 'User not found' });
-            return;
-        }
-
-        const {
-            studentId,
-        } = request.body.data;
-
-        await _assertUserCanManageStudent(user, studentId, response);
-
-        response.send({
-            isOutOfDate: await _doesStudentInfoRequireReview(studentId, { request, response })
-        });
+    if (!user) {
+        // getUserFromRequest already sent a 403.
+        return;
     }
-);
+
+    const { studentId } = request.body.data;
+
+    await _assertUserCanManageStudent(user, studentId, response);
+
+    response.send({
+        isOutOfDate: await _doesStudentInfoRequireReview(studentId, {
+            request,
+            response,
+        }),
+    });
+});

--- a/libs/firebase/enrollment-functions/enroll-addendum/src/lib/enroll-addendum.ts
+++ b/libs/firebase/enrollment-functions/enroll-addendum/src/lib/enroll-addendum.ts
@@ -31,7 +31,7 @@ export const enrollAddendum = Functions.endpoint
         const user = await AuthUtility.getUserFromRequest(request, response);
 
         if (!user) {
-            response.status(401).send({ error: 'User not found' });
+            // getUserFromRequest already sent a 403.
             return;
         }
 
@@ -301,10 +301,9 @@ export const enrollAddendum = Functions.endpoint
                         if (!('classes' in originalEnrollment)) {
                             throw new Error('Legacy format not supported');
                         }
-                        const originalClass =
-                            originalEnrollment.classes.find(
-                                (c) => c.id === classId
-                            );
+                        const originalClass = originalEnrollment.classes.find(
+                            (c) => c.id === classId
+                        );
                         if (!originalClass) {
                             throw new Error(
                                 `Class ${classId} not found in original enrollment`
@@ -327,8 +326,7 @@ export const enrollAddendum = Functions.endpoint
             ];
             const failedClasses = allResults
                 .filter(
-                    (r): r is PromiseRejectedResult =>
-                        r.status === 'rejected'
+                    (r): r is PromiseRejectedResult => r.status === 'rejected'
                 )
                 .map((r) => r.reason?.message ?? 'Unknown error');
 
@@ -348,8 +346,7 @@ export const enrollAddendum = Functions.endpoint
             await ClassEnrollmentRepository.create({
                 ...enrollmentRecord,
                 relatedId: pendingEnrollmentId,
-                failures:
-                    errors?.deepErrors().map((e) => e.message) ?? [],
+                failures: errors?.deepErrors().map((e) => e.message) ?? [],
                 status: 'failed',
             });
             response.send({

--- a/libs/firebase/enrollment-functions/enroll/src/lib/enroll.ts
+++ b/libs/firebase/enrollment-functions/enroll/src/lib/enroll.ts
@@ -35,7 +35,7 @@ export const enroll = Functions.endpoint
         const user = await AuthUtility.getUserFromRequest(request, response);
 
         if (!user) {
-            response.status(401).send({ error: 'User not found' });
+            // getUserFromRequest already sent a 403.
             return;
         }
 
@@ -229,8 +229,7 @@ export const enroll = Functions.endpoint
             await ClassEnrollmentRepository.create({
                 ...enrollmentRecord,
                 relatedId: studentEnrollmentId,
-                failures:
-                    errors?.deepErrors().map((e) => e.message) ?? [],
+                failures: errors?.deepErrors().map((e) => e.message) ?? [],
                 releaseSignatures,
                 status: 'failed',
             });

--- a/libs/firebase/enrollment-functions/get-enrollment-for-addendum/src/lib/get-enrollment-for-addendum.ts
+++ b/libs/firebase/enrollment-functions/get-enrollment-for-addendum/src/lib/get-enrollment-for-addendum.ts
@@ -8,7 +8,7 @@ export const getEnrollmentForAddendum = Functions.endpoint.handle<{
     const user = await AuthUtility.getUserFromRequest(request, response);
 
     if (!user) {
-        response.status(401).send({ error: 'User not found' });
+        // getUserFromRequest already sent a 403.
         return;
     }
 
@@ -34,7 +34,9 @@ export const getEnrollmentForAddendum = Functions.endpoint.handle<{
     if (!('classes' in enrollment)) {
         response
             .status(400)
-            .send({ error: 'Legacy enrollment format not supported for addendums' });
+            .send({
+                error: 'Legacy enrollment format not supported for addendums',
+            });
         return;
     }
 
@@ -52,19 +54,20 @@ export const getEnrollmentForAddendum = Functions.endpoint.handle<{
     if (openSemesterIds.length === 0) {
         response
             .status(400)
-            .send({ error: 'No semesters in this enrollment are still open for registration' });
+            .send({
+                error: 'No semesters in this enrollment are still open for registration',
+            });
         return;
     }
 
     // Get all prior addendums for this enrollment to know total existing selections
-    const allAddendums = await ClassEnrollmentRepository.getAddendumsByOriginalId(enrollmentId);
+    const allAddendums =
+        await ClassEnrollmentRepository.getAddendumsByOriginalId(enrollmentId);
 
     // Combine all classes and options from original + all addendums
     const allEnrolledClasses = [
         ...enrollment.classes,
-        ...allAddendums.flatMap((a) =>
-            'classes' in a ? a.classes : []
-        ),
+        ...allAddendums.flatMap((a) => ('classes' in a ? a.classes : [])),
     ];
     const allAdditionalOptionIdsByClassId: Record<string, Array<string>> = {};
 

--- a/libs/firebase/enrollment-functions/get-my-student/src/lib/get-my-student.ts
+++ b/libs/firebase/enrollment-functions/get-my-student/src/lib/get-my-student.ts
@@ -73,7 +73,7 @@ export const getMyStudent = Functions.endpoint.handle<{ studentId: string }>(
     async (request, response) => {
         const user = await AuthUtility.getUserFromRequest(request, response);
         if (!user) {
-            response.send({ studentIds: [] });
+            // getUserFromRequest already sent a 403.
             return;
         }
         const { studentId } = request.body.data;

--- a/libs/firebase/enrollment-functions/load-enrollment-draft/src/lib/load-enrollment-draft.ts
+++ b/libs/firebase/enrollment-functions/load-enrollment-draft/src/lib/load-enrollment-draft.ts
@@ -6,7 +6,7 @@ export const loadEnrollmentDraft = Functions.endpoint.handle(
         const user = await AuthUtility.getUserFromRequest(request, response);
 
         if (!user) {
-            response.status(401).send({ error: 'User not found' });
+            // getUserFromRequest already sent a 403.
             return;
         }
 

--- a/libs/firebase/enrollment-functions/my-enrolled-students/src/lib/my-enrolled-students.ts
+++ b/libs/firebase/enrollment-functions/my-enrolled-students/src/lib/my-enrolled-students.ts
@@ -8,7 +8,7 @@ export const myEnrolledStudents = Functions.endpoint.handle(
         const user = await AuthUtility.getUserFromRequest(request, response);
 
         if (!user) {
-            response.send({ students: [] });
+            // getUserFromRequest already sent a 403.
             return;
         }
 
@@ -32,30 +32,38 @@ export const myEnrolledStudents = Functions.endpoint.handle(
             .filter(
                 (student): student is NonNullable<typeof student> => !!student
             )
-            .map(({ id, first_name, last_name, birth_date, completed_units }) => {
-                const currentClasses = enrollmentsByStudent
-                    .filter((e: SemesterEnrollment) => e.studentId === id)
-                    .flatMap((e: SemesterEnrollment) =>
-                        'classes' in e && Array.isArray(e.classes)
-                            ? e.classes
-                            : []
-                    )
-                    .filter(
-                        (c): c is { id: string; semesterId: string } =>
-                            c != null && typeof c.id === 'string'
-                    );
-
-                return {
+            .map(
+                ({
                     id,
-                    name: `${first_name} ${last_name}`,
-                    birthday: birth_date,
-                    completedUnitsCount: completed_units?.length ?? 0,
-                    currentClasses: currentClasses.map((c) => ({
-                        id: c.id,
-                        semesterId: c.semesterId,
-                    })),
-                };
-            });
+                    first_name,
+                    last_name,
+                    birth_date,
+                    completed_units,
+                }) => {
+                    const currentClasses = enrollmentsByStudent
+                        .filter((e: SemesterEnrollment) => e.studentId === id)
+                        .flatMap((e: SemesterEnrollment) =>
+                            'classes' in e && Array.isArray(e.classes)
+                                ? e.classes
+                                : []
+                        )
+                        .filter(
+                            (c): c is { id: string; semesterId: string } =>
+                                c != null && typeof c.id === 'string'
+                        );
+
+                    return {
+                        id,
+                        name: `${first_name} ${last_name}`,
+                        birthday: birth_date,
+                        completedUnitsCount: completed_units?.length ?? 0,
+                        currentClasses: currentClasses.map((c) => ({
+                            id: c.id,
+                            semesterId: c.semesterId,
+                        })),
+                    };
+                }
+            );
 
         response.send({ students });
     }

--- a/libs/firebase/enrollment-functions/payment-token/src/lib/payment-token.ts
+++ b/libs/firebase/enrollment-functions/payment-token/src/lib/payment-token.ts
@@ -8,21 +8,21 @@ export const paymentToken = Functions.endpoint
         anonymous?: boolean;
     }>(async (request, response, secrets, strings) => {
         const { anonymous = false } = request.body.data || {};
-        
+
         const braintree = new Braintree(secrets, strings);
-        
+
         if (anonymous) {
             const token = await braintree.getAnonymousClientToken();
             response.send(token);
             return;
         }
-        
+
         const user = await AuthUtility.getUserFromRequest(request, response);
         if (!user) {
-            response.status(401).send({ error: 'Unauthorized' });
+            // getUserFromRequest already sent a 403.
             return;
         }
-        
+
         const token = await braintree.getClientToken(user);
         response.send(token);
     });

--- a/libs/firebase/enrollment-functions/roles/src/lib/roles.ts
+++ b/libs/firebase/enrollment-functions/roles/src/lib/roles.ts
@@ -3,7 +3,7 @@ import { AuthUtility, Functions } from '@sol/firebase/functions';
 export const roles = Functions.endpoint.handle(async (request, response) => {
     const user = await AuthUtility.getUserFromRequest(request, response);
     if (!user) {
-        response.send({ roles: [] });
+        // getUserFromRequest already sent a 403.
         return;
     }
     const roles = await AuthUtility.getUserRoles(user);

--- a/libs/firebase/enrollment-functions/update-enrollment-draft/src/lib/update-enrollment-draft.ts
+++ b/libs/firebase/enrollment-functions/update-enrollment-draft/src/lib/update-enrollment-draft.ts
@@ -9,7 +9,7 @@ export const updateEnrollmentDraft = Functions.endpoint.handle<
     const user = await AuthUtility.getUserFromRequest(request, response);
 
     if (!user) {
-        response.status(401).send({ error: 'User not found' });
+        // getUserFromRequest already sent a 403.
         return;
     }
 


### PR DESCRIPTION
## Problem

Follow-up to #226. Eleven handlers authenticate via `AuthUtility.getUserFromRequest`, which already sends a **403** when there's no valid token. But on the `!user` branch they sent a *second* response:

```ts
const user = await AuthUtility.getUserFromRequest(request, response);
if (!user) {
    response.status(401).send({ error: 'User not found' }); // 403 already sent → throws
    return;
}
```

On an unauthenticated request this threw `ERR_HTTP_HEADERS_SENT` — an unhandled rejection that intermittently poisoned concurrent requests (the lingering nondeterministic `500`s on admin endpoints). The second response never reached the client anyway; the 403 from `validateFirebaseIdToken` always won.

## Fix

Align all eleven with the pattern already used correctly elsewhere (e.g. `send-test-enrollment-email`): just `return` after `getUserFromRequest` has responded. **No change to observable behavior** — these endpoints still return 403 when unauthenticated; the dead 401/empty-array responses are removed.

Handlers updated: `enroll`, `enrollAddendum`, `paymentToken`, `roles`, `myEnrolledStudents`, `getMyStudent`, `loadEnrollmentDraft`, `deleteEnrollmentDraft`, `updateEnrollmentDraft`, `doesStudentInfoRequireReview`, `getEnrollmentForAddendum`.

## Tests

Added `unauthenticated-handlers.spec.ts` asserting each endpoint returns 403 (not 200) without a token. Full integration suite: **111/111**, deterministic, with **zero `ERR_HTTP_HEADERS_SENT`** across repeated runs (previously intermittently 1).

## Note on the empty-array endpoints

`roles`/`myEnrolledStudents`/`getMyStudent` were written as if to return an empty payload for a logged-out user, but that never reached the client (it threw) — they've always returned 403. This PR preserves that 403. If a graceful empty-200 for unauthenticated is actually wanted, that's a deliberate product change requiring `getUserFromRequest` to become non-sending (it has other callers that rely on it sending the 403), and frontend coordination — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)