### PR TITLE
ci: run lint + unit tests on PRs

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -22,6 +22,25 @@ jobs:
             - run: npx nx run student-portal:build:production
             - run: npx nx run functions:build
 
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        if: github.repository == 'MountainSOLSchool/platform'
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'npm'
+            - name: Derive affected SHAs
+              uses: nrwl/nx-set-shas@v4
+            - run: npm ci
+            - name: Lint affected projects
+              run: npx nx affected -t lint --parallel=4
+
     storybook:
         name: Storybook Build & Tests
         runs-on: ubuntu-latest

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -41,6 +41,25 @@ jobs:
             - name: Lint affected projects
               run: npx nx affected -t lint --parallel=4
 
+    unit-tests:
+        name: Unit Tests
+        runs-on: ubuntu-latest
+        if: github.repository == 'MountainSOLSchool/platform'
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'npm'
+            - name: Derive affected SHAs
+              uses: nrwl/nx-set-shas@v4
+            - run: npm ci
+            - name: Test affected projects
+              run: npx nx affected -t test --exclude=functions-integration-tests --parallel=4
+
     storybook:
         name: Storybook Build & Tests
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

First step of bringing Mountain SOL's CI up to parity with maple-and-spruce so big refactors (e.g. the PrimeNG→Material migration, #222) can land safely. Adds two missing PR gates to `build-check.yml`, both using `nrwl/nx-set-shas@v4` + `nx affected`:

1. **Lint** — previously ran only on the husky pre-commit hook, so anything bypassing the hook reached `main` unlinted.
2. **Unit Tests** — component/unit Jest specs (e.g. `class-card`'s 17-test regression spec) **existed but were never run in CI**; build-check only ran build, storybook, and the emulator integration suite. Now `nx affected -t test` gates PRs (excluding `functions-integration-tests`, which needs emulators and runs in its own job).

## Verification

- `nx run-many -t lint` → all 51 lint targets pass
- `nx run-many -t test` (excl. integration) → green

Both gates therefore land green rather than red-on-arrival.

## Scope decisions (deliberately excluded)

- **Per-project typecheck CI job** — the `build` job already typechecks all lib code reachable from the 3 app builds.
- **Converting build/integration to `nx affected`** — maple does this for its 17 integration suites; SOL has 1 suite (~2.5min), and affected-gating it would *reduce* safety for negligible speed gain.

## Next in the parity effort

- TestBed component specs for the components the PrimeNG→Material PR touches (using the `class-card` spec as the template) — now actually enforced by the Unit Tests gate.
- Playwright enrollment smoke test against emulators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)