### PR TITLE
feat(ci): wire dedicated dev Firebase project (#231)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,2 +1,2 @@
 BRAINTREE_ENV=DEV
-ALLOWED_ORIGINS=http://localhost:4200,http://localhost:4201,http://127.0.0.1:4200,http://127.0.0.1:4201,http://davidsmacbook.local:4200,http://davidsmacbook.local:4201
+ALLOWED_ORIGINS=http://localhost:4200,http://localhost:4201,http://127.0.0.1:4200,http://127.0.0.1:4201,http://davidsmacbook.local:4200,http://davidsmacbook.local:4201,https://mountain-sol-platform-dev.web.app,https://mountain-sol-platform-dev.firebaseapp.com

--- a/.env.emulator
+++ b/.env.emulator
@@ -1,0 +1,2 @@
+BRAINTREE_ENV=DEV
+ALLOWED_ORIGINS=http://localhost:4200,http://localhost:4201,http://127.0.0.1:4200,http://127.0.0.1:4201,http://davidsmacbook.local:4200,http://davidsmacbook.local:4201

--- a/.firebaserc
+++ b/.firebaserc
@@ -2,6 +2,7 @@
     "projects": {
         "default": "mountain-sol-platform",
         "dev": "mountain-sol-platform-dev",
-        "prod": "mountain-sol-platform"
+        "prod": "mountain-sol-platform",
+        "emulator": "mountain-sol-platform"
     }
 }

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,7 +1,7 @@
 {
     "projects": {
         "default": "mountain-sol-platform",
-        "dev": "mountain-sol-platform",
+        "dev": "mountain-sol-platform-dev",
         "prod": "mountain-sol-platform"
     }
 }

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -113,8 +113,11 @@ jobs:
                   BRAINTREE_VENMO_PROFILE_ID=fake_venmo_profile_id
                   BRAINTREE_VENMO_PROFILE_ID_PROD=fake_venmo_profile_id_prod
                   EOF
+            # Pin the emulator project to mountain-sol-platform: the seed
+            # helpers hardcode that project id in their REST URLs, and the
+            # `dev` alias now points at the real dev project (deploy-only).
             - name: Run integration tests with emulators
-              run: npx firebase emulators:exec --project=dev --only auth,firestore,functions "npx nx run functions-integration-tests:test"
+              run: npx firebase emulators:exec --project=mountain-sol-platform --only auth,firestore,functions "npx nx run functions-integration-tests:test"
 
     enrollment-e2e:
         name: Enrollment E2E
@@ -153,7 +156,7 @@ jobs:
             # to the wrapped command, so global-setup seeds the right ports. The
             # e2e target's Playwright webServer serves the app in emulator mode.
             - name: Run enrollment E2E with emulators
-              run: npx firebase emulators:exec --project=dev --config firebase.e2e.json --only auth,firestore,functions "npx nx run enrollment-portal-e2e:e2e"
+              run: npx firebase emulators:exec --project=mountain-sol-platform --config firebase.e2e.json --only auth,firestore,functions "npx nx run enrollment-portal-e2e:e2e"
             - name: Upload Playwright report on failure
               if: failure()
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -85,6 +85,11 @@ jobs:
     integration-tests:
         name: Firebase Integration Tests
         runs-on: ubuntu-latest
+        # Fail fast if the emulators hang on startup instead of burning the
+        # 6h job default (an unauthenticated emulators:exec given a literal
+        # real project id stalls fetching prod config — see the `emulator`
+        # alias below).
+        timeout-minutes: 25
         if: github.repository == 'MountainSOLSchool/platform'
         steps:
             - uses: actions/checkout@v4
@@ -113,15 +118,20 @@ jobs:
                   BRAINTREE_VENMO_PROFILE_ID=fake_venmo_profile_id
                   BRAINTREE_VENMO_PROFILE_ID_PROD=fake_venmo_profile_id_prod
                   EOF
-            # Pin the emulator project to mountain-sol-platform: the seed
-            # helpers hardcode that project id in their REST URLs, and the
-            # `dev` alias now points at the real dev project (deploy-only).
+            # Use the `emulator` alias (-> mountain-sol-platform), NOT the
+            # literal project id: firebase-tools treats a literal id as an
+            # explicit prod project and, when unauthenticated (as CI is),
+            # stalls fetching its Admin SDK config. An alias key keeps the
+            # emulators offline. The alias resolves to the same id the seed
+            # helpers + app config hardcode, so no singleProjectMode bridging.
             - name: Run integration tests with emulators
-              run: npx firebase emulators:exec --project=mountain-sol-platform --only auth,firestore,functions "npx nx run functions-integration-tests:test"
+              run: npx firebase emulators:exec --project=emulator --only auth,firestore,functions "npx nx run functions-integration-tests:test"
 
     enrollment-e2e:
         name: Enrollment E2E
         runs-on: ubuntu-latest
+        # Fail fast if the emulators hang on startup (see integration-tests).
+        timeout-minutes: 25
         if: github.repository == 'MountainSOLSchool/platform'
         steps:
             - uses: actions/checkout@v4
@@ -156,7 +166,7 @@ jobs:
             # to the wrapped command, so global-setup seeds the right ports. The
             # e2e target's Playwright webServer serves the app in emulator mode.
             - name: Run enrollment E2E with emulators
-              run: npx firebase emulators:exec --project=mountain-sol-platform --config firebase.e2e.json --only auth,firestore,functions "npx nx run enrollment-portal-e2e:e2e"
+              run: npx firebase emulators:exec --project=emulator --config firebase.e2e.json --only auth,firestore,functions "npx nx run enrollment-portal-e2e:e2e"
             - name: Upload Playwright report on failure
               if: failure()
               uses: actions/upload-artifact@v4

--- a/apps/enrollment-portal/project.json
+++ b/apps/enrollment-portal/project.json
@@ -54,6 +54,31 @@
                     ],
                     "outputHashing": "all"
                 },
+                "dev": {
+                    "budgets": [
+                        {
+                            "type": "initial",
+                            "maximumWarning": "1mb",
+                            "maximumError": "2mb"
+                        },
+                        {
+                            "type": "anyComponentStyle",
+                            "maximumWarning": "2kb",
+                            "maximumError": "4kb"
+                        }
+                    ],
+                    "fileReplacements": [
+                        {
+                            "replace": "apps/enrollment-portal/src/environments/environment.ts",
+                            "with": "apps/enrollment-portal/src/environments/environment.dev.ts"
+                        },
+                        {
+                            "replace": "libs/ts/firebase/firebase-config/src/lib/sol-firebase-config.ts",
+                            "with": "libs/ts/firebase/firebase-config/src/lib/sol-firebase-config.dev.ts"
+                        }
+                    ],
+                    "outputHashing": "all"
+                },
                 "development": {
                     "buildOptimizer": false,
                     "optimization": false,
@@ -86,6 +111,9 @@
             "configurations": {
                 "production": {
                     "buildTarget": "enrollment-portal:build:production"
+                },
+                "dev": {
+                    "buildTarget": "enrollment-portal:build:dev"
                 },
                 "development": {
                     "buildTarget": "enrollment-portal:build:development",

--- a/apps/enrollment-portal/src/environments/environment.dev.ts
+++ b/apps/enrollment-portal/src/environments/environment.dev.ts
@@ -1,0 +1,10 @@
+// Deployed-dev environment: a prod-like optimized build that targets the
+// dev Firebase project (via the dev web config swapped in by the `dev` build
+// configuration). remoteFunctions = true so callables hit the dev project's
+// deployed functions; useEmulators = false (this runs against deployed dev,
+// not the local emulator).
+export const environment = {
+    production: true,
+    remoteFunctions: true,
+    useEmulators: false,
+};

--- a/apps/functions-integration-tests/project.json
+++ b/apps/functions-integration-tests/project.json
@@ -18,7 +18,7 @@
         "test-with-emulators": {
             "executor": "nx:run-commands",
             "options": {
-                "command": "npx nx run functions:build && firebase emulators:exec --project=mountain-sol-platform --only auth,firestore,functions \"npx nx run functions-integration-tests:test\""
+                "command": "npx nx run functions:build && firebase emulators:exec --project=emulator --only auth,firestore,functions \"npx nx run functions-integration-tests:test\""
             }
         }
     }

--- a/apps/functions-integration-tests/project.json
+++ b/apps/functions-integration-tests/project.json
@@ -7,7 +7,9 @@
     "targets": {
         "test": {
             "executor": "@nx/jest:jest",
-            "outputs": ["{workspaceRoot}/coverage/apps/functions-integration-tests"],
+            "outputs": [
+                "{workspaceRoot}/coverage/apps/functions-integration-tests"
+            ],
             "options": {
                 "jestConfig": "apps/functions-integration-tests/jest.config.ts",
                 "runInBand": true
@@ -16,7 +18,7 @@
         "test-with-emulators": {
             "executor": "nx:run-commands",
             "options": {
-                "command": "npx nx run functions:build && firebase emulators:exec --project=dev --only auth,firestore,functions \"npx nx run functions-integration-tests:test\""
+                "command": "npx nx run functions:build && firebase emulators:exec --project=mountain-sol-platform --only auth,firestore,functions \"npx nx run functions-integration-tests:test\""
             }
         }
     }

--- a/libs/ts/firebase/firebase-config/src/lib/sol-firebase-config.dev.ts
+++ b/libs/ts/firebase/firebase-config/src/lib/sol-firebase-config.dev.ts
@@ -1,0 +1,15 @@
+import { FirebaseOptions } from '@firebase/app';
+
+// Dev project web config (sol-web-dev app on mountain-sol-platform-dev).
+// Swapped in for sol-firebase-config.ts by the enrollment-portal `dev` build
+// configuration so the deployed-dev portal authenticates and calls functions
+// against the dev project rather than prod. Web API keys are public client-side
+// identifiers (same as the prod config), safe to commit.
+export const solFirebaseConfig: FirebaseOptions = {
+    apiKey: 'AIzaSyDzw8zRBy5ruIkkwEnnExsiCGN8bl5L52k',
+    authDomain: 'mountain-sol-platform-dev.firebaseapp.com',
+    projectId: 'mountain-sol-platform-dev',
+    storageBucket: 'mountain-sol-platform-dev.firebasestorage.app',
+    messagingSenderId: '1062901014652',
+    appId: '1:1062901014652:web:9385be3945a0cce84069f9',
+};


### PR DESCRIPTION
Closes #231. Part of #230.

## What
Wire the dedicated dev Firebase project (`mountain-sol-platform-dev`) into the repo and give the enrollment-portal a `dev` build that actually targets it.

## Why this is more than a one-line `.firebaserc` change
The portal's Firebase web config was **hardcoded to prod** (`sol-firebase-config.ts` → `projectId: mountain-sol-platform`). In prod mode the app calls functions via the Firebase SDK's `httpsCallable`, which goes straight to `…-mountain-sol-platform.cloudfunctions.net` and **bypasses hosting rewrites**; Auth uses the same hardcoded config. So a build deployed to dev hosting would still talk to **prod**. A real dev tier needs a dev web config selected at build time — the maple `VITE_TARGET_ENV=dev` equivalent.

## Changes
- **`.firebaserc`**: `dev` → `mountain-sol-platform-dev` (prod/default unchanged).
- **`sol-firebase-config.dev.ts`** + **`environment.dev.ts`**: dev web config (public client-side keys for the `sol-web-dev` app) + a prod-like runtime (`remoteFunctions: true`, `useEmulators: false`).
- **enrollment-portal `dev` build + serve configurations**: optimized like `production`, with `fileReplacements` for both the environment and the Firebase web config. Verified the dev `apiKey`/`projectId` are baked into the bundle and the prod `apiKey` is absent.
- **`.env.dev` `ALLOWED_ORIGINS`**: added `https://mountain-sol-platform-dev.web.app` + `.firebaseapp.com` so deployed dev functions accept the dev portal (CORS) once functions deploy to dev in #232.
- **Emulator suite pinning**: the integration + enrollment-e2e suites seed via REST helpers that hardcode the `mountain-sol-platform` project id. Repointing the `dev` alias would otherwise boot those emulators under `mountain-sol-platform-dev` and break Auth-emulator routing. Pinned both CI jobs (`build-check.yml`) and the local `test-with-emulators` command to `--project=mountain-sol-platform` so their behavior is byte-identical to before.

The local `firebase serve --project=dev` functions commands are intentionally left as `dev`: they run only locally and now correctly point at the dev project (the desired dev experience).

## Scope boundary
Deploy auth (**Workload Identity Federation**) and the dev deploy jobs land in #232/#233. This PR is the app + alias wiring only — nothing here deploys anything, so it's inert until those land. **Owner WIF console setup is needed before #232** — exact steps posted as a comment on #231.

## Verification
- `nx run enrollment-portal:build:dev` succeeds; dev config confirmed in the output bundle (prod apiKey absent).
- `nx run enrollment-portal:lint` clean (pre-existing warnings only).
- Emulator suites unchanged in behavior (project id pinned to the value the seed helpers expect).
