### PR TITLE
fix(ci): skip orphan function libs not exported in functions/index.ts

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -86,12 +86,24 @@ jobs:
                     AFFECTED=$(npx nx show projects --affected --base=${{ steps.base.outputs.commit }} | grep 'firebase-enrollment-functions-' || true)
                   fi
 
+                  # Only functions actually wired into the deploy entry point
+                  # are deployable. A function library can exist without being
+                  # exported from apps/functions/src/functions/index.ts (e.g. the
+                  # orphaned current-semester lib) — `firebase deploy --only
+                  # functions:<name>` fails with "No function matches the filter"
+                  # for those. Build the set of exported names and skip the rest.
+                  EXPORTED=$(grep -oE "export \{ [a-zA-Z0-9_]+ \}" apps/functions/src/functions/index.ts | sed -E 's/export \{ ([a-zA-Z0-9_]+) \}/\1/')
+
                   FUNCTIONS=()
                   while IFS= read -r lib; do
                     FUNC_NAME=${lib#firebase-enrollment-functions-}
                     if [ "$FUNC_NAME" != "shared" ]; then
                       FUNC_NAME=$(echo "$FUNC_NAME" | awk -F'-' '{for(i=1;i<=NF;i++){if(i==1){printf("%s",$i)}else{printf("%s%s",toupper(substr($i,1,1)),substr($i,2))}}}')
-                      FUNCTIONS+=("$FUNC_NAME")
+                      if echo "$EXPORTED" | grep -qx "$FUNC_NAME"; then
+                        FUNCTIONS+=("$FUNC_NAME")
+                      else
+                        echo "Skipping $lib -> $FUNC_NAME (not exported in functions/index.ts)"
+                      fi
                     fi
                   done <<< "$AFFECTED"
 


### PR DESCRIPTION
Follow-up surfaced by #232's `deploy_all` verification.

The deploy matrix derived function names from `firebase-enrollment-functions-*` lib names, but a function lib can exist without being wired into `apps/functions/src/functions/index.ts`. `current-semester` is exactly that — a real `Functions.endpoint.handle(...)` that's **never exported or imported anywhere** (dead code). So the matrix included `functions:currentSemester`, and `firebase deploy --only functions:currentSemester` fails with `No function matches the filter` → with fail-fast, it cancelled the rest of the matrix (the `deploy_all` run got 9/16 groups before hitting it).

**Fix:** filter the matrix to function names actually exported in `index.ts` (77 of them) and skip the rest, logging what's dropped. Robust to current + future orphans, for both `deploy_all` and affected-based runs.

Verified locally: simulating the matrix logic keeps all 77 deployable functions and skips only `currentSemester`.

(The orphaned `current-semester` lib itself is dead code that could be deleted, but that's a separate cleanup for the owner — out of scope here.)