### PR TITLE
feat(ci): deployed-dev e2e gate (E2E_TARGET=dev) — Step A (#234)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -5,7 +5,8 @@ name: Deploy on merge
 #   merge to main
 #     ├── prepare_and_build       (compute affected functions, build artifact)
 #     ├── deploy_functions_dev    (affected functions -> mountain-sol-platform-dev, WIF)
-#     └── deploy_hosting_dev       (enrollment-portal `dev` build -> dev Hosting, WIF)
+#     ├── deploy_hosting_dev       (enrollment-portal `dev` build -> dev Hosting, WIF)
+#     └── e2e_dev                  (core enrollment Playwright vs the deployed dev stack)
 #
 # As of #232/#233 this workflow deploys to DEV ONLY. Dev deploys via keyless
 # Workload Identity Federation (a short-lived access token minted by
@@ -331,3 +332,63 @@ jobs:
                 done
                 echo "::error::dev hosting deploy failed after 3 attempts"
                 exit 1
+
+    e2e_dev:
+        # The gate: run the core enrollment E2E against the deployed dev stack
+        # (portal on dev Hosting + callables on the dev project). Seeds dev
+        # Firestore/Auth via the Admin SDK over ADC. Runs once both dev deploys
+        # are healthy; deploy_functions_dev is skipped on no-op merges, so treat
+        # skipped as ok. always() is needed because a skipped need would
+        # otherwise skip this job too.
+        needs: [deploy_functions_dev, deploy_hosting_dev]
+        if: >-
+          always() &&
+          (needs.deploy_functions_dev.result == 'success' || needs.deploy_functions_dev.result == 'skipped') &&
+          needs.deploy_hosting_dev.result == 'success'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                fetch-depth: 1
+
+            # create_credentials_file exports GOOGLE_APPLICATION_CREDENTIALS so
+            # the Admin SDK seed/teardown reaches dev Firestore/Auth via ADC.
+            - name: Authenticate to Google Cloud (Dev)
+              uses: google-github-actions/auth@v2
+              with:
+                  workload_identity_provider: 'projects/1062901014652/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+                  service_account: 'github-deployer@mountain-sol-platform-dev.iam.gserviceaccount.com'
+                  create_credentials_file: true
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                # Pinned 22.22.3: Node 22.23.0 regressed node-fetch keep-alive
+                # (false "Premature close" on concurrent requests) — maple #503.
+                node-version: '22.22.3'
+                cache: 'npm'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Install Playwright browser
+              run: npx playwright install --with-deps chromium
+
+            - name: Run deployed-dev E2E
+              env:
+                  E2E_TARGET: dev
+                  GOOGLE_CLOUD_PROJECT: mountain-sol-platform-dev
+              run: npx nx run enrollment-portal-e2e:e2e
+
+            - name: Upload Playwright report on failure
+              if: failure()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-report-dev
+                  path: |
+                      apps/enrollment-portal-e2e/playwright-report/**
+                      apps/enrollment-portal-e2e/test-results/**
+                  retention-days: 7

--- a/apps/enrollment-portal-e2e/playwright.config.ts
+++ b/apps/enrollment-portal-e2e/playwright.config.ts
@@ -1,14 +1,36 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = process.env['E2E_BASE_URL'] ?? 'http://localhost:4200';
+/**
+ * Runs the same specs against either backend, picked by `E2E_TARGET`:
+ *
+ * - `emulator` (default) — PR check: the Angular app on a local dev server in
+ *   emulator mode, callables on the local Firebase emulator. Boots the app via
+ *   the `webServer` block. Pair with `firebase emulators:exec`.
+ * - `dev` — post-merge gate: the deployed portal on dev Hosting
+ *   (mountain-sol-platform-dev.web.app), callables on the deployed dev project.
+ *   No `webServer`; baseURL points at the deployed site. Seed runs against the
+ *   real dev Firestore/Auth via the Admin SDK (see seed-admin.ts).
+ */
+const target = process.env['E2E_TARGET'] ?? 'emulator';
+
+const DEFAULT_DEV_URL = 'https://mountain-sol-platform-dev.web.app';
+
+const baseURL =
+    process.env['E2E_BASE_URL'] ??
+    (target === 'dev' ? DEFAULT_DEV_URL : 'http://localhost:4200');
 
 export default defineConfig({
     testDir: './src/e2e',
-    testMatch: '**/*.spec.ts',
+    // Against deployed dev, run only the core enrollment paths (basic $0 flow).
+    // The full variation matrix stays on the emulator PR job.
+    testMatch: target === 'dev' ? '**/enrollment.spec.ts' : '**/*.spec.ts',
     globalSetup: './src/global-setup.ts',
+    globalTeardown: './src/global-teardown.ts',
     outputDir: './test-results',
-    timeout: 90_000,
-    expect: { timeout: 15_000 },
+    // Deployed-dev callables can cold-start past the emulator's budget,
+    // especially on the first request after a deploy.
+    timeout: target === 'dev' ? 120_000 : 90_000,
+    expect: { timeout: target === 'dev' ? 20_000 : 15_000 },
     workers: 1,
     fullyParallel: false,
     retries: process.env['CI'] ? 1 : 0,
@@ -24,14 +46,18 @@ export default defineConfig({
         video: 'retain-on-failure',
         screenshot: 'only-on-failure',
     },
-    webServer: {
-        command: 'npx nx run enrollment-portal:serve:emulator',
-        url: baseURL,
-        cwd: '../..',
-        timeout: 180_000,
-        reuseExistingServer: !process.env['CI'],
-        stdout: 'pipe',
-        stderr: 'pipe',
-    },
+    // Local dev server is only needed in emulator mode; in dev mode the portal
+    // is already deployed to Hosting.
+    ...(target === 'emulator' && {
+        webServer: {
+            command: 'npx nx run enrollment-portal:serve:emulator',
+            url: baseURL,
+            cwd: '../..',
+            timeout: 180_000,
+            reuseExistingServer: !process.env['CI'],
+            stdout: 'pipe',
+            stderr: 'pipe',
+        },
+    }),
     projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 });

--- a/apps/enrollment-portal-e2e/src/global-setup.ts
+++ b/apps/enrollment-portal-e2e/src/global-setup.ts
@@ -6,14 +6,25 @@ import {
     seedStaleStudent,
     writeAddendumEnrollmentId,
 } from './support/seed';
+import { seedDev } from './support/seed-admin';
 import { E2E_USERS } from './support/test-users';
 
 /**
- * Runs once before the Playwright suite, inside `firebase emulators:exec`
- * (so FIRESTORE_EMULATOR_HOST / FIREBASE_AUTH_EMULATOR_HOST are already set).
- * Seeds the shared catalog plus one user per scenario.
+ * Runs once before the Playwright suite. Branches on E2E_TARGET:
+ *
+ * - `dev` — seed the deployed dev project via the Admin SDK (seed-admin.ts).
+ *   Only the `fresh` scenario is needed for the deployed core enrollment spec.
+ * - `emulator` (default) — seed the local emulators via REST, inside
+ *   `firebase emulators:exec` (FIRESTORE/AUTH emulator host env already set).
+ *   Seeds the shared catalog plus one user per scenario.
  */
 export default async function globalSetup(): Promise<void> {
+    if (process.env['E2E_TARGET'] === 'dev') {
+        await seedDev();
+        console.log('[e2e] global-setup: seeded dev catalog + fresh user');
+        return;
+    }
+
     await clearAll();
     await seedBaseFixtures();
 

--- a/apps/enrollment-portal-e2e/src/global-teardown.ts
+++ b/apps/enrollment-portal-e2e/src/global-teardown.ts
@@ -1,0 +1,23 @@
+import { teardownDev } from './support/seed-admin';
+
+/**
+ * Runs once after the suite.
+ *
+ * - `emulator` — nothing to do; the emulator process exits with the job,
+ *   discarding all seeded state.
+ * - `dev` — delete the seeded catalog + everything the run created (test user,
+ *   its students/enrollments/draft) so the deployed dev project doesn't
+ *   accumulate test data. Best-effort: a teardown hiccup shouldn't fail the
+ *   run, since the test result is the real signal.
+ */
+export default async function globalTeardown(): Promise<void> {
+    if (process.env['E2E_TARGET'] !== 'dev') {
+        return;
+    }
+    try {
+        await teardownDev();
+        console.log('[e2e] global-teardown: removed dev fixtures + run data');
+    } catch (err) {
+        console.error('[e2e] global-teardown failed (continuing):', err);
+    }
+}

--- a/apps/enrollment-portal-e2e/src/support/seed-admin.ts
+++ b/apps/enrollment-portal-e2e/src/support/seed-admin.ts
@@ -1,0 +1,237 @@
+/**
+ * Admin-SDK seed/teardown for the deployed-dev e2e (E2E_TARGET=dev).
+ *
+ * The emulator suite seeds via the Firestore/Auth REST APIs (seed.ts). Against
+ * the deployed dev project there's no emulator REST surface, so we seed the real
+ * `mountain-sol-platform-dev` Firestore + Auth through firebase-admin. Credentials
+ * come from Application Default Credentials (GOOGLE_APPLICATION_CREDENTIALS — set
+ * in CI by google-github-actions/auth, or `gcloud auth application-default login`
+ * locally).
+ *
+ * Fixtures mirror seed.ts (same SEED ids + shapes the functions read through) so
+ * the same specs assert against either backend. Teardown removes the seeded
+ * fixtures plus anything the run created (the test user, its students, drafts and
+ * enrollments) so dev doesn't accumulate test data.
+ */
+import { getApps, initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { SEED } from './seed';
+import { E2E_USERS } from './test-users';
+
+const DEV_PROJECT_ID = 'mountain-sol-platform-dev';
+
+function app() {
+    if (getApps().length === 0) {
+        // Explicit projectId avoids "could not load default credentials" when the
+        // WIF credential file carries no embedded project_id.
+        initializeApp({ projectId: DEV_PROJECT_ID });
+    }
+}
+
+const db = () => {
+    app();
+    return getFirestore();
+};
+const auth = () => {
+    app();
+    return getAuth();
+};
+
+/**
+ * Retry a Firestore/Auth op on transient connection failures. In CI the Admin
+ * SDK gets credentials keylessly; the first call triggers an STS token exchange
+ * (sts.googleapis.com via WIF) whose HTTPS connection intermittently drops with
+ * "Premature close" etc. gax's own retries don't always ride it out, which would
+ * fail the whole suite at setup/teardown. Non-transient errors throw immediately.
+ */
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    const MAX_ATTEMPTS = 4;
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastErr = err;
+            const msg = err instanceof Error ? err.message : String(err);
+            const transient =
+                /Premature close|metadata from plugin|sts\.googleapis\.com|ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket hang up|fetch failed|UNAVAILABLE|DEADLINE_EXCEEDED|Getting metadata|503|429/i.test(
+                    msg
+                );
+            if (!transient || attempt === MAX_ATTEMPTS) break;
+            const delayMs = 1000 * 2 ** (attempt - 1); // 1s, 2s, 4s
+            console.warn(
+                `[e2e] ${label} attempt ${attempt}/${MAX_ATTEMPTS} failed (${msg}); retrying in ${delayMs}ms`
+            );
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+    }
+    throw lastErr;
+}
+
+const futureDate = (() => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() + 1);
+    return d;
+})();
+const pastDate = (() => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() - 1);
+    return d;
+})();
+
+// ClassDbo shape — mirror of makeClassDoc in seed.ts, with admin Timestamps.
+function makeClassDoc(overrides: Record<string, unknown> = {}) {
+    return {
+        name: 'E2E Class',
+        description: 'Seeded by the e2e suite',
+        live: true,
+        cost: 0,
+        location: 'Room A',
+        weekday: 'Monday',
+        daily_times: '9:00 AM - 12:00 PM',
+        class_type: 'Standard',
+        grade_range_start: 1,
+        grade_range_end: 12,
+        thumbnailUrl: '',
+        paused_for_enrollment: false,
+        for_information_only: false,
+        max_student_size: 12,
+        min_student_size: 1,
+        instructors: [],
+        students: [],
+        start: Timestamp.fromDate(pastDate),
+        end: Timestamp.fromDate(futureDate),
+        registration_end_date: Timestamp.fromDate(futureDate),
+        ...overrides,
+    };
+}
+
+/** Create the scenario Auth user fresh (delete any leftover from a prior run). */
+async function recreateUser(email: string, password: string): Promise<void> {
+    await withRetry(`seed:user:${email}`, async () => {
+        try {
+            const existing = await auth().getUserByEmail(email);
+            await auth().deleteUser(existing.uid);
+        } catch {
+            // No existing user — fine.
+        }
+        await auth().createUser({ email, password });
+    });
+}
+
+/**
+ * Seed the active semester, a FREE open class (cost 0 => enroll()'s no-payment
+ * path), a PAID class + add-on, an active discount, and the `fresh` scenario
+ * user. Idempotent: fixed doc ids are overwritten and the user is recreated.
+ */
+export async function seedDev(): Promise<void> {
+    await withRetry('seed:fixtures', () =>
+        Promise.all([
+            db().doc('config/activeSemester').set({ id: SEED.semesterId }),
+            db()
+                .doc('config/otherSemestersAvailableToEnroll')
+                .set({ list: [] }),
+            db()
+                .doc(`semesters/${SEED.semesterId}`)
+                .set({ displayName: SEED.semesterDisplayName }),
+            db()
+                .doc(`semesters/${SEED.semesterId}/classes/${SEED.freeClassId}`)
+                .set(
+                    makeClassDoc({
+                        name: SEED.freeClassName,
+                        cost: 0,
+                        students: [],
+                    })
+                ),
+            db()
+                .doc(`semesters/${SEED.semesterId}/classes/${SEED.paidClassId}`)
+                .set(
+                    makeClassDoc({
+                        name: SEED.paidClassName,
+                        cost: SEED.paidClassCost,
+                        students: [],
+                    })
+                ),
+            db()
+                .doc(
+                    `semesters/${SEED.semesterId}/classes/${SEED.freeClassId}/additional_options/${SEED.paidOptionId}`
+                )
+                .set({
+                    description: SEED.paidOptionDescription,
+                    cost: SEED.paidOptionCost,
+                    students: [],
+                }),
+            // Fixed id (REST seed uses an auto-id; DiscountRepository matches on
+            // `code`, so the doc id is irrelevant — fixed keeps it idempotent).
+            db().doc('discounts/e2e-discount').set({
+                code: SEED.discountCode,
+                type: 'percent',
+                active: true,
+                percent: SEED.discountPercent,
+            }),
+        ])
+    );
+
+    await recreateUser(E2E_USERS.fresh.email, E2E_USERS.fresh.password);
+}
+
+/**
+ * Remove everything the run touched: the test user, its enrollment_draft, the
+ * students + enrollments it created, and the seeded catalog. Idempotent and
+ * best-effort — missing docs are ignored.
+ */
+export async function teardownDev(): Promise<void> {
+    const firestore = db();
+
+    // The fresh user's created data (enrollments reference userId + studentId).
+    let freshUid: string | undefined;
+    try {
+        freshUid = (await auth().getUserByEmail(E2E_USERS.fresh.email)).uid;
+    } catch {
+        freshUid = undefined;
+    }
+
+    if (freshUid) {
+        const enrollments = await withRetry('teardown:queryEnrollments', () =>
+            firestore
+                .collection('enrollment')
+                .where('userId', '==', freshUid)
+                .get()
+        );
+        const studentIds = new Set<string>();
+        enrollments.docs.forEach((d) => {
+            const sid = d.get('studentId');
+            if (typeof sid === 'string') studentIds.add(sid);
+        });
+        await withRetry('teardown:deleteEnrollments', () =>
+            Promise.all(enrollments.docs.map((d) => d.ref.delete()))
+        );
+        await withRetry('teardown:deleteStudents', () =>
+            Promise.all(
+                [...studentIds].map((id) =>
+                    firestore.doc(`students/${id}`).delete()
+                )
+            )
+        );
+        await withRetry('teardown:deleteDraft', () =>
+            firestore.doc(`enrollment_draft/${freshUid}`).delete()
+        );
+        await withRetry('teardown:deleteUser', () =>
+            auth().deleteUser(freshUid as string)
+        );
+    }
+
+    // Seeded catalog. recursiveDelete clears the semester's classes +
+    // additional_options subcollections.
+    await withRetry('teardown:deleteSemester', () =>
+        firestore.recursiveDelete(firestore.doc(`semesters/${SEED.semesterId}`))
+    );
+    await withRetry('teardown:deleteRest', () =>
+        Promise.all([
+            firestore.doc('config/activeSemester').delete(),
+            firestore.doc('config/otherSemestersAvailableToEnroll').delete(),
+            firestore.doc('discounts/e2e-discount').delete(),
+        ])
+    );
+}

--- a/apps/enrollment-portal-e2e/src/support/seed.ts
+++ b/apps/enrollment-portal-e2e/src/support/seed.ts
@@ -130,6 +130,12 @@ export async function clearAll(): Promise<void> {
  * Draft doc location: enrollment_draft/{userId} (_deleteEnrollmentDraft.ts).
  */
 export async function clearEnrollmentDrafts(): Promise<void> {
+    // Dev target has no emulator REST surface. The dev seed recreates the test
+    // user with a fresh uid each run, so there's no stale draft to clear — and
+    // global-teardown removes the user's draft anyway. No-op against dev.
+    if (process.env['E2E_TARGET'] === 'dev') {
+        return;
+    }
     await deleteFirestoreCollection('enrollment_draft');
 }
 


### PR DESCRIPTION
Part of #230. Closes #234 (Step A — core path; Step B Braintree-sandbox paid flow follows).

## What
Run the **core enrollment E2E against the deployed dev stack** after each merge (portal on dev Hosting + callables on the dev project), gating promotion. Reuses `apps/enrollment-portal-e2e` with a new `E2E_TARGET=dev` mode alongside the existing emulator mode.

## How
- **Target-aware `playwright.config.ts`** — `dev` → `baseURL = https://mountain-sol-platform-dev.web.app`, no `webServer`, wider timeouts (deployed cold-starts), `testMatch` narrowed to `enrollment.spec.ts` (basic $0 enrollment). Emulator mode unchanged; the full variation matrix stays on the PR job.
- **`seed-admin.ts`** — seeds/tears down the real dev Firestore + Auth via **firebase-admin over ADC**, mirroring the REST seed's fixtures (same `SEED` ids/shapes). Includes the **`withRetry`** helper that absorbs the transient WIF/STS "Premature close" blips the keyless Admin SDK hits on its first call (maple #502), and a **teardown** that removes the seeded catalog + everything the run created (test user, its students/enrollments/draft) so dev doesn't accumulate.
- **`global-setup` branches** on `E2E_TARGET` (dev → Admin seed; emulator → REST); **`global-teardown`** cleans up in dev, no-ops for emulator. `clearEnrollmentDrafts()` no-ops against dev.
- **`e2e_dev` job** — `needs: [deploy_functions_dev, deploy_hosting_dev]`, WIF auth with `create_credentials_file` (ADC for the seed), **Node pinned `22.22.3`** (node-fetch keep-alive regression — maple #503), runs `E2E_TARGET=dev`.

## Verification
- **Emulator path unaffected** — this PR's `build-check` → Enrollment E2E exercises the unchanged emulator flow (global-setup else-branch, webServer, REST seed) and must stay green.
- **Dev path** validated post-merge: the `e2e_dev` job runs against deployed dev (and the in-flight `deploy_all` is confirming the functions/hosting it depends on). The dev seed uses the Firestore/Storage you bootstrapped.

## Scope
Step A = basic $0 enrollment (the highest-value smoke test against real dev). **Step B** adds the Braintree-sandbox paid enrollment (driving Braintree hosted-field iframes with sandbox card `4111…`), staged separately so the gate lands even while that fiddly browser-tokenization is iterated.
