### PR TITLE
perf(ci): deploy affected functions in one command, not 16 batches

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -117,7 +117,18 @@ jobs:
 
                   echo "has_changes=true" >> $GITHUB_OUTPUT
 
-                  GROUP_SIZE=5
+                  # Deploy all affected functions in ONE `firebase deploy`
+                  # command (one matrix entry) rather than batches of 5. Every
+                  # separate deploy re-uploads the ~4 MB source, re-runs the
+                  # "ensuring API X enabled" checks, and re-does function
+                  # discovery — so 16 sequential batches spent most of their
+                  # wall time on that repeated overhead. A single command pays it
+                  # once. (We can't parallelize further: this is a single Firebase
+                  # codebase, and concurrent deploys to one codebase race on
+                  # Firebase's "deployment in progress" lock — hence max-parallel
+                  # stays 1. True parallel deploys would require splitting into
+                  # multiple codebases, maple-style.) Large GROUP_SIZE => one group.
+                  GROUP_SIZE=10000
                   TOTAL=${#FUNCTIONS[@]}
                   NUM_GROUPS=$(( (TOTAL + GROUP_SIZE - 1) / GROUP_SIZE ))
 


### PR DESCRIPTION
You flagged maple's deploy-speed work — here's the part that applies to platform's **single** functions codebase.

## What
Deploy all affected functions in **one** `firebase deploy` command instead of sequential batches of 5 (`GROUP_SIZE` 5 → 10000 ⇒ one matrix entry). Verified locally: a full deploy goes from **16 groups → 1**.

## Why it's faster
Every separate deploy re-uploads the ~4 MB source, re-runs all the "ensuring API X enabled" checks, and re-does function discovery. The `deploy_all` run spent most of its ~40 min on that repeated overhead across 16 sequential commands. One command pays it once.

## What this does *not* do (and why)
- **`max-parallel` stays 1.** Platform has a single Firebase codebase, and concurrent `firebase deploy` commands against one codebase race on Firebase's "deployment in progress" lock (maple hit + documented this).
- **The headline maple win** (~60min → ~4 parallel deploys, #432) came from first **splitting functions into 4 codebases** (#178). That's the real lever for platform too — true parallel deploys *and* faster cold starts — but it's a substantial refactor (separate entry points, `firebase.json` codebases, per-codebase builds, function→codebase mapping). Happy to scope it as its own issue if you want it.

Most-affecting on large deploys (`deploy_all`, shared-lib changes); typical small merges already fit in one batch.