### PR TITLE
feat(e2e): deployed-dev Braintree-sandbox paid enrollment — Step B (#234)

### DIFF
--- a/apps/enrollment-portal-e2e/playwright.config.ts
+++ b/apps/enrollment-portal-e2e/playwright.config.ts
@@ -21,9 +21,11 @@ const baseURL =
 
 export default defineConfig({
     testDir: './src/e2e',
-    // Against deployed dev, run only the core enrollment paths (basic $0 flow).
-    // The full variation matrix stays on the emulator PR job.
-    testMatch: target === 'dev' ? '**/enrollment.spec.ts' : '**/*.spec.ts',
+    // Against deployed dev, run the core enrollment paths: the basic $0 flow
+    // plus the Braintree-sandbox paid flow. The full variation matrix stays on
+    // the emulator PR job (the regex excludes enrollment-variations.spec.ts).
+    testMatch:
+        target === 'dev' ? /enrollment(-payment)?\.spec\.ts$/ : '**/*.spec.ts',
     globalSetup: './src/global-setup.ts',
     globalTeardown: './src/global-teardown.ts',
     outputDir: './test-results',

--- a/apps/enrollment-portal-e2e/src/e2e/enrollment-payment.spec.ts
+++ b/apps/enrollment-portal-e2e/src/e2e/enrollment-payment.spec.ts
@@ -1,0 +1,56 @@
+import { test } from '@playwright/test';
+import {
+    EnrollmentPage,
+    SAMPLE_STUDENT_INFO,
+    SAMPLE_MEDICAL,
+} from '../support/enrollment-page';
+import { E2E_USERS } from '../support/test-users';
+import { SEED } from '../support/seed';
+
+/**
+ * The paid happy path — runs ONLY against deployed dev (E2E_TARGET=dev).
+ *
+ * `enroll()` only skips Braintree when the final total is $0, so completing a
+ * paid enrollment requires real payment. The emulator suite mocks Braintree at
+ * the function level but can't tokenize a card client-side with a mock client
+ * token, so it stops before payment (enrollment-variations.spec.ts). Here we
+ * drive the Braintree Drop-in with a sandbox card end to end against the
+ * deployed dev project, whose functions use Braintree **sandbox** credentials.
+ */
+const isDev = process.env['E2E_TARGET'] === 'dev';
+
+test.describe('Paid enrollment (Braintree sandbox)', () => {
+    test.skip(
+        !isDev,
+        'Runs only against deployed dev (real Braintree sandbox)'
+    );
+
+    test('completes a paid enrollment with a Braintree sandbox card', async ({
+        page,
+    }) => {
+        const flow = new EnrollmentPage(page);
+        await flow.goto();
+
+        // Free class + the $25 paid add-on => $25 total => payment required.
+        const addOnLabel = `${SEED.paidOptionDescription} ($${SEED.paidOptionCost})`;
+        await flow.selectClassByName(SEED.freeClassName, [addOnLabel]);
+        await flow.continue();
+        await flow.signIn(E2E_USERS.fresh.email, E2E_USERS.fresh.password);
+        await flow.continue();
+        await flow.chooseNewStudent();
+        await flow.continue();
+        await flow.fillStudentInfo(SAMPLE_STUDENT_INFO);
+        await flow.continue();
+        await flow.fillMedical(SAMPLE_MEDICAL);
+        await flow.continue();
+        await flow.signReleases();
+        await flow.continue();
+
+        await flow.expectFinalTotal('$25.00');
+        await flow.payWithSandboxCard();
+        await flow.submit();
+        // Braintree sandbox sale + enroll processing can run long on a cold dev
+        // container, so allow more headroom than the $0 path.
+        await flow.expectEnrolled(90_000);
+    });
+});

--- a/apps/enrollment-portal-e2e/src/support/enrollment-page.ts
+++ b/apps/enrollment-portal-e2e/src/support/enrollment-page.ts
@@ -104,6 +104,17 @@ export const SAMPLE_MEDICAL: MedicalData = {
     insuranceId: 'INS-12345',
 };
 
+/**
+ * Standard Braintree sandbox Visa — approves any transaction in the sandbox
+ * environment. Used only by the deployed-dev paid path.
+ * https://developer.paypal.com/braintree/docs/reference/general/testing
+ */
+export const SANDBOX_CARD = {
+    number: '4111111111111111',
+    expiration: '1230', // MM/YY -> 12/30 (Drop-in formats as typed)
+    cvv: '123',
+} as const;
+
 export class EnrollmentPage {
     constructor(private readonly page: Page) {}
 
@@ -420,10 +431,67 @@ export class EnrollmentPage {
      * (enrollment-workflow.component.html:379-431). The title is the stable,
      * assertable success indicator.
      */
-    async expectEnrolled(): Promise<void> {
+    async expectEnrolled(timeout = 30_000): Promise<void> {
         await expect(this.page.getByText('Successfully enrolled!')).toBeVisible(
-            { timeout: 30_000 }
+            { timeout }
         );
+    }
+
+    /**
+     * Pay with a Braintree **sandbox** test card via the Drop-in UI. Only used
+     * by the deployed-dev paid path (the emulator suite never tokenizes a card —
+     * it stops before payment).
+     *
+     * The portal renders braintree-web-drop-in (payment-collector.store.ts).
+     * With multiple payment methods enabled (Card + Venmo), Drop-in opens on a
+     * "Choose a way to pay" list; clicking the Card option activates the card
+     * sheet and reveals the hosted-field iframes, each wrapping a single input.
+     * This merchant collects number + expirationDate only (CVV not required, so
+     * no cvv field renders); we fill the standard Braintree sandbox Visa.
+     *
+     * Validated end-to-end against deployed dev (sandbox sale -> "Successfully
+     * enrolled!"). Drop-in loads asynchronously, so we wait for `.braintree-
+     * loaded` before interacting.
+     */
+    async payWithSandboxCard(card = SANDBOX_CARD): Promise<void> {
+        // Drop-in renders asynchronously after the confirm step, so wait for it
+        // to finish loading before interacting — guarding the click on
+        // count()/isVisible() races the load, finds no option yet, and skips the
+        // click, leaving the hosted fields collapsed.
+        await this.page.locator('.braintree-dropin.braintree-loaded').waitFor();
+
+        // Card + Venmo are both enabled, so Drop-in opens on a "Choose a way to
+        // pay" list; click the Card option to activate the card sheet and reveal
+        // the hosted-field iframes. .first() because Drop-in also renders a
+        // hidden duplicate in the (pre-rendered) card sheet.
+        await this.page
+            .getByRole('button', { name: 'Paying with Card' })
+            .first()
+            .click();
+
+        // Each hosted field is an input inside its own same-origin iframe; fill()
+        // auto-waits for the iframe + input to become visible.
+        await this.page
+            .frameLocator('iframe[id="braintree-hosted-field-number"]')
+            .locator('#credit-card-number')
+            .fill(card.number);
+        await this.page
+            .frameLocator('iframe[id="braintree-hosted-field-expirationDate"]')
+            .locator('#expiration')
+            .fill(card.expiration);
+        // This merchant's Drop-in collects number + expiration only (CVV is not
+        // a required field in its Braintree settings, so no cvv hosted field is
+        // rendered). Fill CVV only if present — the count() is safe here because
+        // the card sheet has already loaded (number/expiration just filled).
+        const cvvFrame = this.page.locator(
+            'iframe[id="braintree-hosted-field-cvv"]'
+        );
+        if ((await cvvFrame.count()) > 0) {
+            await this.page
+                .frameLocator('iframe[id="braintree-hosted-field-cvv"]')
+                .locator('#cvv')
+                .fill(card.cvv);
+        }
     }
 
     /**


### PR DESCRIPTION
**Draft** — Step B of #234. Builds on Step A (#244, merged). Hold merge until Step A's `e2e_dev` is confirmed green and these Drop-in selectors are validated/iterated via CI.

## What
Adds the **paid happy path** to the deployed-dev e2e: free class + the $25 add-on → non-zero total → real payment, driven through the **Braintree Drop-in** with a **sandbox** Visa, end to end against the dev project (which uses Braintree sandbox creds you set).

- `payWithSandboxCard()` drives the Drop-in hosted-field iframes (number/expirationDate/cvv) with the standard sandbox card; `expectEnrolled()` gains an optional timeout (sandbox sale + enroll runs long on a cold dev container).
- `enrollment-payment.spec.ts` — **dev-only** (`test.skip` when `E2E_TARGET != dev`): the emulator can't tokenize a card with a mock client token, so it stops before payment (cf. `enrollment-variations.spec.ts`).
- dev `testMatch` now also includes the payment spec (regex excludes the emulator-only variations spec).

## Why it's a draft
The Braintree **Drop-in DOM** (the card-option container + the `braintree-hosted-field-*` iframe ids) is the one piece I can't validate locally — Drop-in only initializes with real sandbox credentials, which exist on deployed dev. So this very likely needs **one CI iteration** to pin the selectors exactly. Marking draft so we sequence it after Step A proves the deployed-dev harness, then iterate the selectors against a real run.

## Note
The paid run leaves a Braintree **sandbox** transaction (harmless; can't be voided from the e2e). Firestore data it creates (student/enrollment) is cleaned up by the existing dev teardown.