### PR TITLE
fix(functions): lazily init Firebase Admin so deploy discovery works under WIF

### DIFF
--- a/libs/firebase/database/src/lib/utilities/database.config.ts
+++ b/libs/firebase/database/src/lib/utilities/database.config.ts
@@ -1,9 +1,64 @@
+/**
+ * Firebase Admin + Firestore configuration — LAZILY initialized.
+ *
+ * The Admin SDK is NOT initialized at module load. Eager init
+ * (`admin.initializeApp(); export const db = admin.firestore()`) breaks
+ * Firebase's deploy-time function discovery under Workload Identity
+ * Federation: discovery loads this module, and resolving the keyless
+ * external_account credential throws "Could not load the default
+ * credentials" (firebase-admin can't consume the WIF ADC file), so only a
+ * partial set of functions gets discovered/deployed. Lazy init means module
+ * load touches no credentials; the SDK initializes on first real use.
+ *
+ * `db` stays a value-shaped export (via a Proxy) so existing call sites
+ * (`db.collection(...)`) keep working unchanged.
+ */
 import admin from 'firebase-admin';
 
-if (admin.apps.length === 0) {
-    admin.initializeApp();
-}
-export const db = admin.firestore();
+let dbInstance: FirebaseFirestore.Firestore | undefined;
+let settingsApplied = false;
 
-const useEmulator = !!process.env['FIRESTORE_EMULATOR_HOST'];
-db.settings({ ignoreUndefinedProperties: true, preferRest: !useEmulator });
+function ensureAdminInitialized(): void {
+    if (admin.apps.length === 0) {
+        admin.initializeApp();
+    }
+}
+
+/** Lazily initialize and return the Firestore instance (cached). */
+export function getDb(): FirebaseFirestore.Firestore {
+    if (!dbInstance) {
+        ensureAdminInitialized();
+        dbInstance = admin.firestore();
+
+        // settings() must run once, before any operation — guard so a
+        // double-call (or post-use call) can't throw.
+        if (!settingsApplied) {
+            try {
+                const useEmulator = !!process.env['FIRESTORE_EMULATOR_HOST'];
+                dbInstance.settings({
+                    ignoreUndefinedProperties: true,
+                    preferRest: !useEmulator,
+                });
+            } catch {
+                // Already applied / Firestore already in use — ignore.
+            }
+            settingsApplied = true;
+        }
+    }
+    return dbInstance;
+}
+
+/**
+ * Backwards-compatible value-shaped Firestore export. Resolves the real
+ * instance lazily on first property access, so importing/loading this module
+ * (e.g. during deploy-time discovery) never initializes the Admin SDK.
+ */
+export const db = new Proxy({} as FirebaseFirestore.Firestore, {
+    get(_target, prop) {
+        const real = getDb();
+        const value = real[prop as keyof FirebaseFirestore.Firestore];
+        return typeof value === 'function'
+            ? (value as (...args: unknown[]) => unknown).bind(real)
+            : value;
+    },
+});

--- a/libs/firebase/database/src/lib/utilities/prewarm-database.ts
+++ b/libs/firebase/database/src/lib/utilities/prewarm-database.ts
@@ -1,5 +1,16 @@
 import { db } from './database.config';
 
-void (await db.collection('config').doc('activeSemester').get());
+// Cold-start warmup of the Firestore connection — RUNTIME ONLY.
+// Guarded on K_SERVICE (set only in the deployed Cloud Run runtime) so it
+// never runs during Firebase's deploy-time function discovery or locally,
+// where the Admin SDK has no usable credentials. Fire-and-forget: not awaited
+// and errors are swallowed, so it can never block or break module load.
+if (process.env['K_SERVICE']) {
+    void db
+        .collection('config')
+        .doc('activeSemester')
+        .get()
+        .catch(() => undefined);
+}
 
 export {};


### PR DESCRIPTION
## The bug behind the dev-deploy saga
Eager Firebase init at module load broke Firebase's deploy-time function **discovery** under **Workload Identity Federation**:
- `database.config.ts` did `admin.initializeApp(); export const db = admin.firestore()` at module load
- `prewarm-database.ts` did a top-level `await db…get()` (pulled in at module load via `database.utility.ts`)

During discovery firebase loads the functions module; resolving the keyless **external_account** credential throws `Could not load the default credentials` (firebase-admin can't consume the WIF ADC file — firebase-admin-node#2168). So discovery enumerated only a **partial, nondeterministic** set of functions → the deploy created a few (or none) and **exited 0**. That's why only ~30 of 77 functions ever landed in dev despite many "successful" deploys, and the enrollment callables 404'd (read by the e2e as "CORS").

**Prod was fine** because it deploys with a service-account-key (ADC firebase-admin *can* load).

## Fix (maple's proven pattern)
- **`database.config.ts`** → lazy `getDb()` (init + settings on first use); `db` stays value-shaped via a **Proxy** so `db.collection(...)` call sites are unchanged. Module load now touches no credentials.
- **`prewarm-database.ts`** → cold-start warmup runs **only in the deployed runtime** (guard on `K_SERVICE`), fire-and-forget with errors swallowed — never runs/throws during discovery.

## Validation
- Build green.
- **This PR's `build-check`** (Firebase Integration Tests + Enrollment E2E, both against the emulator) exercises the lazy `db` at runtime — the pre-merge proof that behavior is preserved.
- The real test is a dev deploy after merge: discovery should enumerate all 77 and deploy them. I'll verify the live count via the Functions API (not the job's green check).

## Follow-up
A post-deploy **verification guard** so a partial deploy can never again pass as green (the "fail loudly" fix).