### PR TITLE
chore(ci): bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -11,9 +11,9 @@ jobs:
         runs-on: ubuntu-latest
         if: github.repository == 'MountainSOLSchool/platform'
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: 'npm'
@@ -27,11 +27,11 @@ jobs:
         runs-on: ubuntu-latest
         if: github.repository == 'MountainSOLSchool/platform'
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: 'npm'
@@ -46,11 +46,11 @@ jobs:
         runs-on: ubuntu-latest
         if: github.repository == 'MountainSOLSchool/platform'
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: 'npm'
@@ -65,9 +65,9 @@ jobs:
         runs-on: ubuntu-latest
         if: github.repository == 'MountainSOLSchool/platform'
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: 'npm'
@@ -92,14 +92,14 @@ jobs:
         timeout-minutes: 25
         if: github.repository == 'MountainSOLSchool/platform'
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: 'npm'
             - name: Setup Java
-              uses: actions/setup-java@v4
+              uses: actions/setup-java@v5
               with:
                   distribution: 'temurin'
                   java-version: '21'
@@ -134,14 +134,14 @@ jobs:
         timeout-minutes: 25
         if: github.repository == 'MountainSOLSchool/platform'
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: 'npm'
             - name: Setup Java
-              uses: actions/setup-java@v4
+              uses: actions/setup-java@v5
               with:
                   distribution: 'temurin'
                   java-version: '21'
@@ -169,7 +169,7 @@ jobs:
               run: npx firebase emulators:exec --project=emulator --config firebase.e2e.json --only auth,firestore,functions "npx nx run enrollment-portal-e2e:e2e"
             - name: Upload Playwright report on failure
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report-enrollment-e2e
                   path: |

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -52,7 +52,7 @@ jobs:
             has_changes: ${{ steps.get_affected.outputs.has_changes }}
             cache_key: ${{ steps.set_cache_key.outputs.key }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                 fetch-depth: 2
 
@@ -61,7 +61,7 @@ jobs:
               run: echo "commit=$(git rev-parse HEAD~1)" >> $GITHUB_OUTPUT
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                 node-version: '22'
                 cache: 'npm'
@@ -178,14 +178,14 @@ jobs:
 
             - name: Cache node_modules for deploy
               if: steps.get_affected.outputs.has_changes == 'true'
-              uses: actions/cache/save@v4
+              uses: actions/cache/save@v6
               with:
                 path: node_modules
                 key: ${{ steps.set_cache_key.outputs.key }}
 
             - name: Upload build artifacts
               if: steps.get_affected.outputs.has_changes == 'true'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                 name: dist-functions
                 path: |
@@ -209,7 +209,7 @@ jobs:
             max-parallel: 1
             matrix: ${{ fromJson(needs.prepare_and_build.outputs.matrix) }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                 fetch-depth: 1
 
@@ -220,7 +220,7 @@ jobs:
             # firebase-tools 15 — see #231 / maple #490.
             - name: Authenticate to Google Cloud (Dev)
               id: auth
-              uses: google-github-actions/auth@v2
+              uses: google-github-actions/auth@v3
               with:
                   workload_identity_provider: 'projects/1062901014652/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
                   service_account: 'github-deployer@mountain-sol-platform-dev.iam.gserviceaccount.com'
@@ -228,15 +228,15 @@ jobs:
                   token_format: 'access_token'
 
             - name: Setup gcloud CLI
-              uses: google-github-actions/setup-gcloud@v2
+              uses: google-github-actions/setup-gcloud@v3
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                 node-version: '22'
 
             - name: Download build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                 name: dist-functions
 
@@ -282,13 +282,13 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                 fetch-depth: 1
 
             - name: Authenticate to Google Cloud (Dev)
               id: auth
-              uses: google-github-actions/auth@v2
+              uses: google-github-actions/auth@v3
               with:
                   workload_identity_provider: 'projects/1062901014652/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
                   service_account: 'github-deployer@mountain-sol-platform-dev.iam.gserviceaccount.com'
@@ -296,10 +296,10 @@ jobs:
                   token_format: 'access_token'
 
             - name: Setup gcloud CLI
-              uses: google-github-actions/setup-gcloud@v2
+              uses: google-github-actions/setup-gcloud@v3
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                 node-version: '22'
                 cache: 'npm'
@@ -361,21 +361,21 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                 fetch-depth: 1
 
             # create_credentials_file exports GOOGLE_APPLICATION_CREDENTIALS so
             # the Admin SDK seed/teardown reaches dev Firestore/Auth via ADC.
             - name: Authenticate to Google Cloud (Dev)
-              uses: google-github-actions/auth@v2
+              uses: google-github-actions/auth@v3
               with:
                   workload_identity_provider: 'projects/1062901014652/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
                   service_account: 'github-deployer@mountain-sol-platform-dev.iam.gserviceaccount.com'
                   create_credentials_file: true
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                 # Pinned 22.22.3: Node 22.23.0 regressed node-fetch keep-alive
                 # (false "Premature close" on concurrent requests) — maple #503.
@@ -396,7 +396,7 @@ jobs:
 
             - name: Upload Playwright report on failure
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report-dev
                   path: |


### PR DESCRIPTION
## What
Bumps all pinned GitHub Actions to their latest majors, all of which ship the Node 24 runtime.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v6 |
| `actions/setup-java` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/cache` / `cache/save` | v4 | v6 |
| `google-github-actions/auth` | v2 | v3 |
| `google-github-actions/setup-gcloud` | v2 | v3 |

## Why
Runners now default to Node 24 and print a deprecation warning for any action whose `action.yml` still bundles the Node 20 runtime (our `@v4`/`@v2` pins). This clears those warnings and gives the longest runway before the next deprecation.

## Notes
- Touches only `.github/workflows/build-check.yml` and `firebase-functions-merge.yml`.
- No `with:` / input changes needed — usage is drop-in for our setup (WIF auth via `create_credentials_file`, save-only cache).
- Validation happens by running these workflows on the PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)