### PR TITLE
ci: build on Node 24 (node-version + engines)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - run: npm ci
             - run: npx nx run enrollment-portal:build:production
@@ -33,7 +33,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - name: Derive affected SHAs
               uses: nrwl/nx-set-shas@v4
@@ -52,7 +52,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - name: Derive affected SHAs
               uses: nrwl/nx-set-shas@v4
@@ -69,7 +69,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - run: npm ci
             - name: Install Playwright browsers
@@ -96,7 +96,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - name: Setup Java
               uses: actions/setup-java@v5
@@ -138,7 +138,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - name: Setup Java
               uses: actions/setup-java@v5

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -63,7 +63,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                node-version: '22'
+                node-version: '24'
                 cache: 'npm'
 
             - name: Generate cache key
@@ -233,7 +233,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                node-version: '22'
+                node-version: '24'
 
             - name: Download build artifacts
               uses: actions/download-artifact@v8
@@ -301,7 +301,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                node-version: '22'
+                node-version: '24'
                 cache: 'npm'
 
             - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
     "main": "dist/apps/functions/main.js",
     "engines": {
-        "node": "22"
+        "node": "24"
     },
     "private": true,
     "overrides": {


### PR DESCRIPTION
Completes the Node 24 move. #262 bumped the GitHub Actions *majors* (`checkout@v7`, `setup-node@v6`, …), which only changes the runtime the **actions themselves** run on. The build still installed/compiled under **Node 22**, because:

- `setup-node`'s `node-version: '22'` was unchanged (9 jobs across both workflows)
- root `engines.node` was still `"22"`

This flips both to **24** so `npm ci`, builds, tests, and the deploy pipeline actually run on Node 24.

## Changes
- `.github/workflows/build-check.yml` + `.github/workflows/firebase-functions-merge.yml`: `node-version: '22' → '24'`
- `package.json`: `engines.node "22" → "24"`

## Deliberately unchanged
- `firebase.json` functions `runtime: "nodejs22"` — Firebase Functions has no `nodejs24` runtime yet. That's the **deployed** runtime, separate from the build Node.

## Why now
The Admin Guide docs PR (#263) regenerated `package-lock.json` under Node 24 / npm 11; CI rejected it because it still ran `npm ci` on Node 22. Once this merges, that branch rebases and the lockfile matches CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)