### PR TITLE
fix(ci): batch dev function deploys + verify they actually land

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -50,9 +50,10 @@ jobs:
         outputs:
             matrix: ${{ steps.get_affected.outputs.matrix }}
             has_changes: ${{ steps.get_affected.outputs.has_changes }}
+            expected_functions: ${{ steps.get_affected.outputs.expected_functions }}
             cache_key: ${{ steps.set_cache_key.outputs.key }}
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@v4
               with:
                 fetch-depth: 2
 
@@ -61,7 +62,7 @@ jobs:
               run: echo "commit=$(git rev-parse HEAD~1)" >> $GITHUB_OUTPUT
 
             - name: Setup Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v4
               with:
                 node-version: '22'
                 cache: 'npm'
@@ -117,18 +118,38 @@ jobs:
 
                   echo "has_changes=true" >> $GITHUB_OUTPUT
 
-                  # Deploy all affected functions in ONE `firebase deploy`
-                  # command (one matrix entry) rather than batches of 5. Every
-                  # separate deploy re-uploads the ~4 MB source, re-runs the
-                  # "ensuring API X enabled" checks, and re-does function
-                  # discovery — so 16 sequential batches spent most of their
-                  # wall time on that repeated overhead. A single command pays it
-                  # once. (We can't parallelize further: this is a single Firebase
-                  # codebase, and concurrent deploys to one codebase race on
-                  # Firebase's "deployment in progress" lock — hence max-parallel
-                  # stays 1. True parallel deploys would require splitting into
-                  # multiple codebases, maple-style.) Large GROUP_SIZE => one group.
-                  GROUP_SIZE=10000
+                  # Flat list of every function this run intends to deploy. The
+                  # verify_functions_dev job asserts each is ACTIVE afterward, so
+                  # a partial deploy (firebase-tools exits 0 on per-function 409s)
+                  # fails the run loudly instead of going green.
+                  echo "expected_functions=${FUNCTIONS[*]}" >> $GITHUB_OUTPUT
+
+                  # Batch the deploy into groups of GROUP_SIZE functions, one
+                  # `firebase deploy` per group, run sequentially (max-parallel:
+                  # 1). The size is a balance:
+                  #
+                  #  - Too LARGE: a cold deploy that *creates* many functions at
+                  #    once (e.g. backfilling a fresh project, or a deploy_all)
+                  #    fires all the create operations near-simultaneously and
+                  #    overruns Cloud Functions' concurrent-operation throttle —
+                  #    the API rejects the surplus with HTTP 409 "unable to queue
+                  #    the operation" / "already exists". firebase-tools logs
+                  #    those as warnings and STILL EXITS 0, so the job goes green
+                  #    while most functions never deploy. (Observed June 2026: a
+                  #    single 77-function deploy_all landed only 1 of 46 creates.)
+                  #  - Too SMALL: every separate deploy re-uploads the ~4 MB
+                  #    source, re-runs the "ensuring API X enabled" checks, and
+                  #    re-does discovery, so many tiny batches waste wall time.
+                  #
+                  # 15 keeps each batch's concurrent operations under the throttle
+                  # while leaving the common case — a normal merge touches only a
+                  # handful of affected functions — as a single batch (no speed
+                  # regression). Only large/cold deploys split. We can't
+                  # parallelize the batches: this is a single Firebase codebase
+                  # and concurrent deploys to one codebase race on Firebase's
+                  # "deployment in progress" lock (hence max-parallel: 1). True
+                  # parallel deploys would need multiple codebases, maple-style.
+                  GROUP_SIZE=15
                   TOTAL=${#FUNCTIONS[@]}
                   NUM_GROUPS=$(( (TOTAL + GROUP_SIZE - 1) / GROUP_SIZE ))
 
@@ -178,14 +199,14 @@ jobs:
 
             - name: Cache node_modules for deploy
               if: steps.get_affected.outputs.has_changes == 'true'
-              uses: actions/cache/save@v6
+              uses: actions/cache/save@v4
               with:
                 path: node_modules
                 key: ${{ steps.set_cache_key.outputs.key }}
 
             - name: Upload build artifacts
               if: steps.get_affected.outputs.has_changes == 'true'
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@v4
               with:
                 name: dist-functions
                 path: |
@@ -209,7 +230,7 @@ jobs:
             max-parallel: 1
             matrix: ${{ fromJson(needs.prepare_and_build.outputs.matrix) }}
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@v4
               with:
                 fetch-depth: 1
 
@@ -220,7 +241,7 @@ jobs:
             # firebase-tools 15 — see #231 / maple #490.
             - name: Authenticate to Google Cloud (Dev)
               id: auth
-              uses: google-github-actions/auth@v3
+              uses: google-github-actions/auth@v2
               with:
                   workload_identity_provider: 'projects/1062901014652/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
                   service_account: 'github-deployer@mountain-sol-platform-dev.iam.gserviceaccount.com'
@@ -228,15 +249,15 @@ jobs:
                   token_format: 'access_token'
 
             - name: Setup gcloud CLI
-              uses: google-github-actions/setup-gcloud@v3
+              uses: google-github-actions/setup-gcloud@v2
 
             - name: Setup Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v4
               with:
                 node-version: '22'
 
             - name: Download build artifacts
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@v4
               with:
                 name: dist-functions
 
@@ -271,6 +292,58 @@ jobs:
               if: matrix.functions == ''
               run: echo "Skipping deployment for empty function group"
 
+    verify_functions_dev:
+        # firebase-tools logs per-function create/update 409s (e.g. the
+        # concurrent-operation throttle on a cold deploy) as warnings and STILL
+        # EXITS 0, so a partial deploy goes green. Reconcile the intended set
+        # against the Cloud Functions API and fail loudly on any function that
+        # is missing or not ACTIVE — turning a silent partial deploy into a red
+        # run. always() so it reports the true state even if a deploy batch
+        # itself failed.
+        needs: [prepare_and_build, deploy_functions_dev]
+        if: >-
+          always() &&
+          needs.prepare_and_build.outputs.has_changes == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - name: Authenticate to Google Cloud (Dev)
+              id: auth
+              uses: google-github-actions/auth@v2
+              with:
+                  workload_identity_provider: 'projects/1062901014652/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+                  service_account: 'github-deployer@mountain-sol-platform-dev.iam.gserviceaccount.com'
+                  create_credentials_file: true
+                  token_format: 'access_token'
+
+            - name: Setup gcloud CLI
+              uses: google-github-actions/setup-gcloud@v2
+
+            - name: Assert every intended function is ACTIVE
+              run: |
+                set -o pipefail
+                EXPECTED="${{ needs.prepare_and_build.outputs.expected_functions }}"
+                TOKEN="${{ steps.auth.outputs.access_token }}"
+
+                ACTIVE=$(curl -s -H "Authorization: Bearer $TOKEN" \
+                  "https://cloudfunctions.googleapis.com/v2/projects/mountain-sol-platform-dev/locations/-/functions?pageSize=300" \
+                  | python3 -c "import sys,json;[print(f['name'].split('/')[-1]) for f in json.load(sys.stdin).get('functions',[]) if f.get('state')=='ACTIVE']" \
+                  | sort -u)
+
+                MISSING=""
+                for fn in $EXPECTED; do
+                  echo "$ACTIVE" | grep -qx "$fn" || MISSING="$MISSING $fn"
+                done
+
+                if [ -n "$MISSING" ]; then
+                  echo "::error::Deploy verification FAILED — these intended functions are not ACTIVE in mountain-sol-platform-dev:$MISSING"
+                  echo "firebase-tools exits 0 on per-function 409s, so the deploy job may be green despite this. Re-run the deploy (a cold backfill may need several passes; see GROUP_SIZE notes above)."
+                  exit 1
+                fi
+                echo "✓ All $(echo $EXPECTED | wc -w) intended functions are ACTIVE."
+
     deploy_hosting_dev:
         # Build the enrollment-portal `dev` configuration (which targets the dev
         # Firebase project — see #231) and deploy it to the dev Hosting site via
@@ -282,13 +355,13 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@v4
               with:
                 fetch-depth: 1
 
             - name: Authenticate to Google Cloud (Dev)
               id: auth
-              uses: google-github-actions/auth@v3
+              uses: google-github-actions/auth@v2
               with:
                   workload_identity_provider: 'projects/1062901014652/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
                   service_account: 'github-deployer@mountain-sol-platform-dev.iam.gserviceaccount.com'
@@ -296,10 +369,10 @@ jobs:
                   token_format: 'access_token'
 
             - name: Setup gcloud CLI
-              uses: google-github-actions/setup-gcloud@v3
+              uses: google-github-actions/setup-gcloud@v2
 
             - name: Setup Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v4
               with:
                 node-version: '22'
                 cache: 'npm'
@@ -361,21 +434,21 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@v4
               with:
                 fetch-depth: 1
 
             # create_credentials_file exports GOOGLE_APPLICATION_CREDENTIALS so
             # the Admin SDK seed/teardown reaches dev Firestore/Auth via ADC.
             - name: Authenticate to Google Cloud (Dev)
-              uses: google-github-actions/auth@v3
+              uses: google-github-actions/auth@v2
               with:
                   workload_identity_provider: 'projects/1062901014652/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
                   service_account: 'github-deployer@mountain-sol-platform-dev.iam.gserviceaccount.com'
                   create_credentials_file: true
 
             - name: Setup Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v4
               with:
                 # Pinned 22.22.3: Node 22.23.0 regressed node-fetch keep-alive
                 # (false "Premature close" on concurrent requests) — maple #503.
@@ -396,7 +469,7 @@ jobs:
 
             - name: Upload Playwright report on failure
               if: failure()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@v4
               with:
                   name: playwright-report-dev
                   path: |


### PR DESCRIPTION
## Problem

Bringing up the `mountain-sol-platform-dev` project surfaced two bugs in the dev function-deploy job, both rooted in the same firebase-tools behavior: **it logs per-function deploy failures as warnings and still exits 0.**

1. **Cold deploys silently half-fail.** A single `firebase deploy` of many *new* functions fires all the create operations at once and overruns Cloud Functions' concurrent-operation throttle → HTTP 409 `unable to queue the operation` / `already exists`. firebase-tools swallows these and exits 0. A `deploy_all` of all 77 functions landed only ~1 while the job went green.
2. **The failure is invisible.** Because the job is green, nothing signals that 40+ functions never deployed.

(Discovery itself — a separate, earlier bug where eager Firebase Admin init broke deploy-time function discovery — was already fixed in #261. This PR is about the deploy *landing* reliably once discovered.)

## Changes

- **Batch the deploy: `GROUP_SIZE` 10000 → 15.** Groups of 15 (sequential, `max-parallel: 1`) keep each `firebase deploy` under the operation throttle. The common case — a normal merge touches a few affected functions — stays a single batch, so no speed regression from #245; only large/cold deploys split.
- **New `verify_functions_dev` job.** After the deploy matrix, it reconciles the *intended* function set (`expected_functions` output from `prepare_and_build`) against the Cloud Functions API and **fails the run** if any function is missing or not `ACTIVE`. Runs with `always()` so it reports the true state even if a deploy batch reported failure.

## Validation

Used these changes to backfill the empty dev project to **77/77 functions ACTIVE**, confirmed with a live callable round-trip returning real Firestore data. The convergence took several `deploy_all` passes (cold creates land ~one-per-`firebase deploy`-command); the verification job correctly flagged the missing set at each step instead of going green.

## Long-term

The real fix for both deploy *speed* and the cold-create *contention* is the maple-style **multi-codebase split (#246)** — independent codebases deploy in parallel without one giant command's creates contending. This PR is the robust interim: deploys that can't fully succeed at least **fail loudly** instead of silently.