### PR TITLE
docs: deploy Admin Guide to GitHub Pages (#249)

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,59 @@
+name: Deploy Docs to Pages
+
+# Builds the Admin Guide (apps/docs) as a static site and publishes it to
+# GitHub Pages. Independent of the Firebase functions/hosting pipeline — the
+# docs site is pure static output with no backend.
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - 'apps/docs/**'
+            - '.github/workflows/docs-pages.yml'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+# Allow one concurrent Pages deployment; let in-flight runs finish.
+concurrency:
+    group: pages
+    cancel-in-progress: false
+
+jobs:
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        if: github.repository == 'MountainSOLSchool/platform'
+        steps:
+            - uses: actions/checkout@v7
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+                  cache: 'npm'
+            - run: npm ci
+            - name: Build static site
+              run: npx nx run docs:build-pages
+              env:
+                  # Project Pages serve under /<repo>. Set to '' once the custom
+                  # domain (docs.mountainsol.org) is live (#259).
+                  DOCS_BASE_PATH: /platform
+            - uses: actions/configure-pages@v5
+            - uses: actions/upload-pages-artifact@v3
+              with:
+                  path: apps/docs/out
+
+    deploy:
+        name: Deploy
+        needs: build
+        runs-on: ubuntu-latest
+        if: github.repository == 'MountainSOLSchool/platform'
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - id: deployment
+              uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,12 @@ firebase-debug.log
 public/
 static/
 
+# Admin Guide (apps/docs) commits its own static assets — screenshots and
+# .nojekyll — so they ship in the Pages build. Re-include it despite the
+# root Firebase `public/` ignore above.
+!apps/docs/public/
+!apps/docs/public/**
+
 migrations.json
 .secret.local
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -9,9 +9,25 @@ wired into Nx via `@nx/next`. Dependencies live in the **root `package.json`**
 
 ```bash
 npx nx run docs:serve        # dev server on http://localhost:4202
-npx nx run docs:build        # production build
-npx nx run docs:export       # static export for GitHub Pages (#249)
+npx nx run docs:build        # production build (server output, via @nx/next)
+npx nx run docs:build-pages  # static export → apps/docs/out (for GitHub Pages)
 ```
+
+## Deploy (GitHub Pages)
+
+On every push to `main` that touches `apps/docs/**`, `.github/workflows/docs-pages.yml`
+builds the static export and publishes it to GitHub Pages (also runnable via
+**workflow_dispatch**).
+
+- Static export is gated behind `DOCS_EXPORT=1` (set by the `build-pages` target),
+  because the `@nx/next:build` executor can't relocate an App-Router static
+  export. `build-pages` runs `next build` directly → `apps/docs/out`.
+- `DOCS_BASE_PATH` sets the path prefix. The workflow uses `/platform` (project
+  Pages serve under `/<repo>`); set it to `''` once the custom domain
+  (`docs.mountainsol.org`) is live (#259).
+- One-time setup: enable Pages with **Settings → Pages → Source: GitHub Actions**.
+- `public/.nojekyll` and committed screenshots under `public/` are force-included
+  via a `.gitignore` negation (the repo otherwise ignores all `public/`).
 
 ## Authoring
 

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -8,14 +8,29 @@ const withNextra = nextra({
     // Nextra 4 reads MDX from the `content/` directory by default.
 });
 
+// GitHub Pages serves the site under a path (the repo name) until the custom
+// domain is wired up. The Pages workflow sets DOCS_BASE_PATH=/platform; locally
+// and on the future custom domain it's empty (served at the root).
+const basePath = process.env.DOCS_BASE_PATH ?? '';
+
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
  */
 const nextConfig = {
     nx: {},
+    // Static HTML export for GitHub Pages (no Node server) — only when building
+    // for Pages (the `build-pages` target sets DOCS_EXPORT=1 and runs
+    // `next build` directly, which emits the site to `out/`). Gated because the
+    // @nx/next:build executor can't relocate an App-Router static export.
+    output: process.env.DOCS_EXPORT === '1' ? 'export' : undefined,
+    // Pages serves each route as a directory/index.html — trailing slashes
+    // avoid 404s on nested routes.
+    trailingSlash: true,
+    basePath: basePath || undefined,
+    // Exposed to the client so <Shot> resolves /public image URLs under basePath.
+    env: { NEXT_PUBLIC_BASE_PATH: basePath },
     // Screenshots are plain files in /public; no Image Optimization server on
-    // GitHub Pages, so keep images unoptimized. Static `output: 'export'` and
-    // basePath for Pages are configured in the deploy work (#249).
+    // GitHub Pages, so keep images unoptimized.
     images: { unoptimized: true },
 };
 

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -38,10 +38,12 @@
                 }
             }
         },
-        "export": {
-            "executor": "@nx/next:export",
+        "build-pages": {
+            "executor": "nx:run-commands",
+            "outputs": ["{projectRoot}/out"],
             "options": {
-                "buildTarget": "docs:build:production"
+                "cwd": "apps/docs",
+                "command": "DOCS_EXPORT=1 npx next build"
             }
         }
     }


### PR DESCRIPTION
Publishes the Admin Guide (`apps/docs`) to GitHub Pages as a static site. Closes #249; part of #260.

## What it does
On every push to `main` touching `apps/docs/**` (or via **workflow_dispatch**), builds the static export and deploys it through the official Pages actions.

## Changes
- **`next.config.mjs`** — `output: 'export'` (gated behind `DOCS_EXPORT=1`), `trailingSlash`, and env-driven `basePath` via `DOCS_BASE_PATH`, so the same source builds correctly locally, on project Pages (`/platform`), and later on the custom domain.
- **`project.json`** — new `build-pages` target runs `next build` **directly**. The `@nx/next:build` executor chokes on relocating an App-Router static export (`pages-manifest.json` ENOENT on `/404`); running Next directly produces `out/` cleanly. `build`/`serve` are unaffected because export is gated.
- **`docs-pages.yml`** — build + deploy jobs (Node 24, `checkout@v7`/`setup-node@v6` to match the repo), path-filtered to `apps/docs`, `concurrency: pages`.
- **`.gitignore`** — re-include `apps/docs/public/`. The root Firebase `public/` ignore was unanchored and silently swallowed it — which would have **blocked committed screenshots** (#258) and `.nojekyll`. Now scoped so only the root Firebase hosting `public/` stays ignored.

## Verified locally
- `nx run docs:build` (non-export) still passes.
- `nx run docs:build-pages` exports all 12 routes to `out/` — basePath `/platform` applied to assets and internal links, nested routes as `dir/index.html`, `404.html` and `.nojekyll` present.

## ⚠️ Before this goes live (needs your call)
1. **One-time:** enable Pages — **Settings → Pages → Source: GitHub Actions** (the deploy job stays pending until then). I can do this via `gh api` if you want.
2. **Visibility (#259):** enabling Pages publishes the guide as **public-but-unlisted** (it's served on `*.github.io` and ships `noindex`, but is reachable by URL). That matches the current default, but it's the first point where internal admin docs become internet-reachable — worth a conscious decision before/at merge. Gating (Cloudflare Access / auth) would be a follow-up under #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)