### PR TITLE
docs(content): Getting Started — admin access & dashboard (#250)

### DIFF
--- a/apps/docs/content/getting-started/admin-access.mdx
+++ b/apps/docs/content/getting-started/admin-access.mdx
@@ -4,22 +4,61 @@ title: Admin access & roles
 
 # Admin access & roles
 
-> _Stub — full content tracked in [#250](https://github.com/MountainSOLSchool/platform/issues/250)._
+Admins use the **same portal and the same email/password sign-in** as families —
+there's no separate admin login. After you sign in, the admin tools appear
+automatically if your account has been granted access.
 
-Mountain SOL staff sign in with the same email/password login families use
-(Firebase Auth). Two admin roles unlock the admin areas:
+<Shot slug="admin-login" caption="The portal sign-in screen (shared with families)." />
 
-- **`admin`** — full access to `/admin/*` (classes, enrollments, discounts,
-  students, reports, t-shirts, messages). Enforced by `admin.guard.ts`.
-- **`medicAdmin`** — access to the separate `/medic/admin/*` area only. Enforced
-  by `medic-admin.guard.ts`.
+## The two kinds of access
 
-Roles are granted via the `roles` Cloud Function; a person needs the role on
-their account before the admin nav appears.
+| Access | What it unlocks |
+| --- | --- |
+| **Admin** | The full admin suite — classes, enrollments, discounts, students, reports, t-shirts, and enrollment messages |
+| **Medic admin** | Only the separate Medic program admin |
 
-<Shot slug="admin-login" caption="The portal sign-in screen." />
+These are independent — a person can have one, both, or neither. Most staff who
+run youth-program enrollment have **Admin**; Medic-program coordinators have
+**Medic admin**. See [Medic Admin](/medic) for that area.
 
-<Shot slug="admin-nav" caption="Admin navigation as seen by an admin user." />
+## What Admin unlocks
 
-**Source:** `apps/enrollment-portal/src/app/admin.guard.ts`,
-`medic-admin.guard.ts`; `roles` function (see `firebase.json`).
+Once your account has Admin access, the **Admin Dashboard** appears at `/admin`
+with links to every area:
+
+- **Manage Classes** — create, edit, copy, and bundle classes ([Class Management](/class-management))
+- **Enrollments** — view, revoke, and refund enrollments ([Enrollment & Discounts](/enrollment-discounts))
+- **Manage Discounts** — discount codes ([Enrollment & Discounts](/enrollment-discounts))
+- **Student Info Sheets**, **Class Forms and Contacts**, **T-shirt Sizes** ([Students & Rosters](/students-rosters))
+- **Enrollment Messages** — banners on the enrollment page ([Semester Setup](/semester-setup))
+
+See the [Dashboard overview](/getting-started/dashboard) for the full map.
+
+<Shot slug="admin-nav" caption="The portal as seen by an admin, with the admin tools available." />
+
+## Getting access (or granting it)
+
+Access is granted by the Mountain SOL team — there's no self-serve setting in the
+portal. The person just needs to have **signed in to the portal at least once**
+so their account exists.
+
+To **get** Admin or Medic-admin access, or to **grant** it to a new staff member,
+contact **david@mountainsol.org** with the staff member's sign-in email and which
+access they need. Removing access works the same way.
+
+> If an admin link or page sends you back to the home screen, your account
+> doesn't have that access yet — reach out to get it added.
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Sign-in: shared Firebase Auth email/password; same login as families.
+  - Roles resolved server-side via the `roles` Cloud Function.
+    Role enum: admin / medic_admin.
+  - Access is stored in Firestore `admins` / `medic_admins` collections keyed by
+    Firebase Auth userId; granting = add a doc, removing = delete it.
+  - Enforced by adminGuard / medicAdminGuard (redirect home) AND a server-side
+    re-check in every admin function.
+  - Source: apps/enrollment-portal/src/app/admin.guard.ts, medic-admin.guard.ts,
+    user.guard.ts; libs/angular/auth/user/.../user.service.ts;
+    libs/firebase/functions/src/lib/utilities/auth.utility.ts.
+*/}

--- a/apps/docs/content/getting-started/dashboard.mdx
+++ b/apps/docs/content/getting-started/dashboard.mdx
@@ -4,14 +4,56 @@ title: Dashboard overview
 
 # Dashboard overview
 
-> _Stub — full content tracked in [#250](https://github.com/MountainSOLSchool/platform/issues/250)._
+When you sign in with Admin access and go to `/admin`, you land on the **Admin
+Dashboard** — the home base for every admin task. It has two parts: a **Quick
+Navigation** list and an **enrollment chart**.
 
-The admin dashboard (`/admin`) is the map for everything else: quick links to
-each admin area, an enrollment chart, and the **semester selector**.
+<Shot slug="admin-dashboard" caption="The Admin Dashboard: quick navigation and the enrollment chart." />
 
-Most admin screens are **scoped to a selected semester** — set it once and the
-classes, enrollments, students, and reports you see all follow it.
+## Quick Navigation
 
-<Shot slug="admin-dashboard" caption="Admin dashboard with the enrollment chart and semester selector." />
+The list links to each admin area. Here's what each one is, and where to read more:
 
-**Source:** `apps/enrollment-portal/src/app/dashboard-component/`.
+| Link | What it's for |
+| --- | --- |
+| **Manage Classes** | Create, edit, copy, and bundle classes — see [Class Management](/class-management) |
+| **Enrollments** | View, revoke, and refund enrollments — see [Enrollment & Discounts](/enrollment-discounts) |
+| **Manage Discounts** | Create and manage discount codes — see [Enrollment & Discounts](/enrollment-discounts) |
+| **Student Info Sheets** | Look up student details, allergies, and health notes — see [Students & Rosters](/students-rosters) |
+| **Class Forms and Contacts** | Per-class rosters, printable forms, and email lists — see [Students & Rosters](/students-rosters) |
+| **T-shirt Sizes** | Size selections and counts for ordering — see [Students & Rosters](/students-rosters) |
+| **Enrollment Messages** | Banners shown on the enrollment page — see [Semester Setup](/semester-setup) |
+| **Class Calendar** | The class calendar view |
+
+> The **Medic program** has its own separate dashboard and isn't listed here —
+> see [Medic Admin](/medic).
+
+## The enrollment chart
+
+Next to the navigation is an **Enrollment** chart — a radar chart showing how many
+students are enrolled in each class, so you can see at a glance which classes are
+filling up and which have room.
+
+Use the **Semester** dropdown above the chart to switch which semester it shows.
+It defaults to the current enrollable semester.
+
+<Shot slug="admin-dashboard-chart" caption="The enrollment radar chart with the semester selector." />
+
+## A note on semesters
+
+Almost every admin screen works **within one semester at a time** — classes,
+enrollments, rosters, reports, and t-shirts all have their own semester picker.
+The dropdown on the dashboard only changes the chart; each screen remembers its
+own selection. Whenever a list looks empty or wrong, check the semester picker
+first.
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Source: apps/enrollment-portal/src/app/dashboard-component/
+    (dashboard.component.ts + .html).
+  - Quick-nav links: /admin/report (Class Forms and Contacts), /admin/students,
+    /admin/t-shirts, /admin/enrollments, /calendar/classes, /admin/classes/management,
+    /admin/discounts, /admin/messages.
+  - Chart: radar of enrolledCount per class from the `classes` function for the
+    selected semester; selector = getEnrollableSemesters(), defaults to first.
+*/}


### PR DESCRIPTION
First real content section. Closes #250; part of #260.

Replaces the two Getting Started stubs with admin-facing content, grounded in the actual auth/dashboard/routing code:

- **Admin access & roles** — shared portal sign-in (same as families), Admin vs Medic-admin access and what each unlocks, and how to get/grant access: **contact david@mountainsol.org**.
- **Dashboard overview** — the Quick Navigation map (cross-linked to every section), the enrollment radar chart + semester selector, and the "check the semester picker first" gotcha.

## Content principles applied
- **No Firebase/Firestore/server internals on the page** — admins don't want "add a doc to the `admins` collection," they want "contact david@." The technical details (roles function, `admins`/`medic_admins` collections, guards) are preserved in **invisible MDX maintainer comments** for whoever updates the docs later.
- **`<Shot>` placeholders** added for each screen (`admin-login`, `admin-nav`, `admin-dashboard`, `admin-dashboard-chart`) — they render "Screenshot pending" until the automation (#258) fills them.

## Verified
`nx run docs:build-pages` exports cleanly; pages render, cross-section links carry the `/platform` basePath, placeholders show.

Once merged, it auto-deploys to https://mountainsolschool.github.io/platform/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)