### PR TITLE
docs(content): Class Management section (#251)

### DIFF
--- a/apps/docs/content/class-management/_meta.js
+++ b/apps/docs/content/class-management/_meta.js
@@ -1,0 +1,5 @@
+export default {
+    index: 'Overview',
+    'creating-a-class': 'Creating & editing a class',
+    'class-groups': 'Class groups',
+};

--- a/apps/docs/content/class-management/class-groups.mdx
+++ b/apps/docs/content/class-management/class-groups.mdx
@@ -1,0 +1,55 @@
+---
+title: Class groups
+---
+
+# Class groups
+
+A **class group** bundles two or more classes together at a single discounted
+price. When a family selects the whole bundle during enrollment, they pay the
+group price instead of the sum of the individual classes — handy for things like a
+*Morning + Afternoon Full Day*.
+
+Open it from **Class Groups** on the [Manage Classes](/class-management) toolbar
+(or go to `/admin/classes/management/groups`). Groups are per-semester — pick the
+semester at the top.
+
+<Shot slug="class-groups" caption="The Class Groups screen." />
+
+## What you see
+
+Each group is a card showing:
+
+- the **group name**,
+- the **group price**, with a **savings** badge versus paying for the classes
+  individually, and
+- the **classes in the group**, each with its individual cost.
+
+**Edit** and **Delete** buttons sit on each card. If there are no groups yet,
+you'll see a **Create First Group** button.
+
+## Creating or editing a group
+
+Click **Create Group** (or **Edit** on a card) to open the dialog:
+
+| Field | Notes |
+| --- | --- |
+| **Group Name** | What families see, e.g. *Morning + Afternoon Full Day*. |
+| **Group Cost** | The bundled price the family pays for all the classes together. |
+| **Select Classes** | Check the classes to include — **at least two**. Each shows its individual cost. |
+
+As you pick classes and set a price, a green **savings** badge shows how much the
+bundle saves versus the individual prices. The **Create / Update Group** button
+stays disabled until the group has a name and **two or more** classes.
+
+<Shot slug="class-group-dialog" caption="The create/edit class group dialog." />
+
+> A class that's already in a group won't appear in the list for another group. If
+> every class is already grouped, you'll see *"All classes are already in groups."*
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Route: /admin/classes/management/groups?semesterId. Components: ClassGroupListComponent,
+    ClassGroupFormDialogComponent.
+  - Min 2 classes enforced; savings = sum(individual) - group cost.
+  - Source: libs/angular/classes/class-management/class-group-list/.
+*/}

--- a/apps/docs/content/class-management/creating-a-class.mdx
+++ b/apps/docs/content/class-management/creating-a-class.mdx
@@ -1,0 +1,144 @@
+---
+title: Creating & editing a class
+---
+
+# Creating & editing a class
+
+Click **Create New Class** on the [Manage Classes](/class-management) screen (or
+**Edit** on an existing class) to open the class form. It's one long form, grouped
+into sections. You can **save a draft at any time** — only *publishing* a class
+requires every field to be filled in correctly (see [Visibility](#visibility)).
+
+<Shot slug="class-form-overview" caption="The class creation form." />
+
+## Basic information
+
+| Field | Notes |
+| --- | --- |
+| **Semester** | Which semester the class belongs to (pre-filled from the screen you came from). |
+| **Class Name** | Required. The name families see, e.g. *Forest Explorers*. |
+| **Description** | What students will learn. This is a [markdown editor](#the-description-editor) with **Write** and **Preview** tabs. |
+| **Class Type** | Required. A label like *Homeschool* or *Camp*; suggestions appear as you type. |
+| **Age Group** | *Zorros and Jaguares* is the standard group (leave it as the default for most classes). *Mallards* and *Mapaches* are the younger groups and change how [units](#units) work. |
+
+### The description editor
+
+The Description field is a small markdown editor:
+
+- **Write** tab — type your text. Toolbar buttons add **bold**, *italic*, bulleted
+  and numbered lists, and links.
+- **Preview** tab — see how it will look.
+
+Markdown basics: `**bold**`, `*italic*`, `- list item`, `[link text](https://…)`.
+
+## Class image
+
+Upload the picture shown on the class card. **Drag and drop** an image onto the box
+or click to browse. JPG, PNG, WebP, and GIF are supported, up to **5 MB**. After
+selecting, you'll see a preview with an **✕** to remove it and pick another.
+
+> Use a clear, landscape-oriented photo — it's displayed wide on the class card.
+
+<Shot slug="class-form-image" caption="The class image upload area with a preview." />
+
+## Schedule
+
+| Field | Notes |
+| --- | --- |
+| **Start Date** / **End Date** | The first and last class meetings. |
+| **Registration End Date** | The last day families can enroll. |
+| **Day(s) of Week** | Pick the meeting days. A preview shows how it'll read to families — e.g. *M-F*, *Weekends*, or *M, W, F*. |
+| **Start / End Time** | Set the class times. A preview shows the friendly form, e.g. *9am-12pm*. |
+| **Location** | Where the class meets; suggestions appear as you type. |
+
+## Enrollment settings
+
+| Field | Notes |
+| --- | --- |
+| **Minimum / Maximum Grade** | The grade range, from 2nd to 12th. |
+| **Minimum Students** | The fewest students needed to run the class. |
+| **Maximum Students** | The cap — once reached, the class is full. |
+
+## Pricing
+
+- **Cost ($)** — the standard price for the class.
+- **Enable sliding scale pricing** — turn this on to let families **choose what they
+  pay within a range**. It reveals a **Minimum ($)** and **Maximum ($)**. On the
+  class list and enrollment page the price then shows as a range (e.g. *$120 -
+  $180*). Use this for pay-what-you-can / affordability.
+
+<Shot slug="class-form-pricing" caption="Pricing with sliding scale enabled." />
+
+## Additional options
+
+Optional **paid add-ons** families can choose during enrollment — e.g. an extra
+hour of care, or a field-trip fee.
+
+1. Turn on **Enable additional options**.
+2. For each add-on, fill in a **Description** (e.g. *Additional hour after class,
+   4pm-5pm*) and a **Cost ($)**.
+3. Use **Add Option** for more, or the red trash icon to remove one.
+
+## Instructors
+
+**Select Instructors** — choose one or more instructors from the list (shown as
+first and last name). At least one is required to publish.
+
+## Units
+
+Units are the skills/badges students earn by completing the class. The **unit
+selector** shows a header with how many are selected and a **Clear All** button.
+
+- For standard classes (Zorros and Jaguares), units are laid out **by path** in
+  columns — each path lists its **Required** units and elective groups, plus an
+  **Other** column for units not in a path.
+- For **Mallards / Mapaches**, units show as a simple list.
+
+Check the units this class grants. Hover the info icon on a unit to see its
+description.
+
+<Shot slug="class-form-units" caption="The unit selector in paths view." />
+
+## Visibility
+
+Three toggles at the bottom control what families see. They map to the
+[statuses](/class-management#class-statuses) on the class list:
+
+- **Publish class (visible to public)** — makes the class **Live** and enrollable.
+- **Pause enrollment (visible but not enrollable)** — keep the class visible but
+  turn off the enroll button (**Paused**).
+- **Information only (no enrollment)** — show the class for info with no enrollment
+  (**Info Only**).
+
+Leaving **Publish** off keeps the class a **Draft** (admin-only).
+
+<Shot slug="class-form-visibility" caption="The visibility toggles." />
+
+### Why you might not be able to publish
+
+You can save a **Draft** with missing fields, but to **publish** (turn on
+*Publish class*) every required field must be valid: Semester, Class Name, Class
+Type, Start/End/Registration dates, days, times, Location, and at least one
+instructor.
+
+If something's missing, the **Publish** toggle is disabled and a **Why can't I
+publish?** link appears that lists exactly what to fix.
+
+## Saving
+
+- **Create Class** / **Save Changes** writes your changes; you'll see a green
+  confirmation, with a **Create Another** shortcut after creating.
+- **Cancel** returns to the list without saving.
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Component: ClassFormComponent. Routes: .../create?semesterId, .../edit/:classId?semesterId.
+  - Required (classValidationSuite): semesterId, name, classType, startDate, endDate,
+    registrationEndDate, weekday, dailyTimes, location, instructorIds(length>0).
+  - Draft (live:false) saves without validation; live:true blocked while invalid.
+  - Sub-widgets: sol-markdown-editor, sol-image-upload (5MB, JPG/PNG/WebP/GIF, no crop UI),
+    sol-weekday-selector, sol-time-range-selector, sol-unit-selector (paths vs age-group view).
+  - Age group "": standard (paths); "mallards"/"mapaches": flat unit list.
+  - Image stored in Cloud Storage (thumbnailUrl) — do not surface to readers.
+  - pausedForEnrollment toggle only present in edit mode.
+*/}

--- a/apps/docs/content/class-management/index.mdx
+++ b/apps/docs/content/class-management/index.mdx
@@ -4,22 +4,87 @@ title: Class Management
 
 # Class Management
 
-> _Stub — full content tracked in [#251](https://github.com/MountainSOLSchool/platform/issues/251)._
+**Manage Classes** (`/admin/classes/management`) is where you create and run the
+classes families enroll in. This page covers the **class list** — the home screen
+for the area. From here you also reach:
 
-The most involved admin area: browse classes by semester and create, edit, copy,
-and bundle them.
+- [Creating & editing a class](/class-management/creating-a-class)
+- [Class groups](/class-management/class-groups) — bundle classes at a discount
+- Semester tools (Add Semester, Info Panel, Email Content) — see [Semester Setup](/semester-setup)
 
-- **Class list** — browse/filter by semester; create, view, copy, edit.
-- **Create or edit a class** — the multi-section form (basic info, image,
-  schedule, enrollment settings, pricing + sliding scale, additional paid
-  options, instructors, units/paths, visibility), validated before publish.
-- **Units & paths** — what students earn on completion; age-group variants.
-- **Class groups** — bundle classes at a discounted price.
+<Shot slug="class-list" caption="The Manage Classes screen for a selected semester." />
 
-<Shot slug="class-list" caption="Admin class list for a semester." />
+## Choosing a semester
 
-<Shot slug="class-form-overview" caption="The class creation/edit form." />
+Everything on this screen is scoped to one semester. Pick it from the **Select
+Semester** dropdown at the top (the current semester is listed first). The toolbar
+next to it has shortcuts:
 
-**Source:** `libs/angular/classes/class-management/` (`class-form/`, `class-list/`,
-`class-group-list/`, `unit-selector/`, `image-upload/`, `weekday-selector/`,
-`time-range-selector/`).
+| Button | What it does |
+| --- | --- |
+| **Add Semester** | Create a new semester — see [Semester Setup](/semester-setup) |
+| **Manage Semesters** | Set the active semester and archive old ones — see [Semester Setup](/semester-setup) |
+| **Info Panel** | Edit the info box on the enrollment page — see [Semester Setup](/semester-setup) |
+| **Email Content** | Edit the enrollment confirmation email — see [Semester Setup](/semester-setup) |
+| **Class Groups** | Bundle classes at a discount — see [Class groups](/class-management/class-groups) |
+
+> The semester buttons are disabled until you've selected a semester.
+
+## The class list
+
+Each class in the selected semester appears as a row:
+
+| Column | What it shows |
+| --- | --- |
+| **Status** | One or more colored tags — **Live** (green), **Draft** (orange), **Paused** (pink), **Info Only** (blue). See [statuses](#class-statuses) below. |
+| **Name** | The class name |
+| **Type** | The class type (e.g. Homeschool, Camp) |
+| **Schedule** | The day(s) on top (e.g. "M-F") and the time below (e.g. "9am-12pm") |
+| **Instructors** | Instructor first names |
+| **Enrolled** | How many are enrolled, and the max if one is set (e.g. "5 / 12") |
+| **Cost** | The price, or a range (e.g. "$120 - $180") if sliding scale is on |
+| **Actions** | Three icons: **View details**, **Edit**, **Copy** |
+
+At the bottom, a summary line reads e.g. *"8 classes • 5 live • 73 total enrolled."*
+
+If the semester has no classes yet, you'll see an empty state with a **Create First
+Class** button.
+
+### Class statuses
+
+The status tags tell you what families can see and do:
+
+| Status | What families see |
+| --- | --- |
+| **Live** | Published and open for enrollment |
+| **Paused** | Visible, but the enroll button is turned off |
+| **Info Only** | Shown for information, with no way to enroll |
+| **Draft** | Not visible to families at all — admin-only |
+
+A class can show more than one tag (for example, a Live class that's currently
+Paused). You set these on the class form — see
+[Visibility](/class-management/creating-a-class#visibility).
+
+## Row actions
+
+- **Create New Class** (top of the screen) — opens the blank class form. See
+  [Creating & editing a class](/class-management/creating-a-class).
+- **View details** (eye icon) — a read-only summary of the class: type, grade
+  range, description, schedule, location, dates, enrollment, cost, any add-on
+  options, and instructors.
+- **Edit** (pencil icon) — opens the class in the form.
+- **Copy** (copy icon) — duplicates the class. A dialog lets you set a **New Class
+  Name** (pre-filled with *"… (Copy)"*) and choose the **Destination Semester**
+  (handy for rolling a class forward to next term). The copy is created as a
+  **Draft** so you can review it before publishing.
+
+<Shot slug="class-copy-dialog" caption="The Copy Class dialog." />
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Route: /admin/classes/management (classManagementRoutes). Component: AdminClassListComponent.
+  - Status flags: live, pausedForEnrollment, forInformationOnly; Draft = live:false.
+  - Copy resets live=false, pausedForEnrollment=false, renames to user input; copies the rest.
+  - Toolbar routes: groups, info-panel/:semesterId, enrollment-email/:semesterId; Add/Manage Semesters are dialogs (reload on save).
+  - Source: libs/angular/classes/class-management/ (class-list/, copy-class dialog, class-detail dialog).
+*/}


### PR DESCRIPTION
The biggest content section. Closes #251; part of #260.

Replaces the stub with three pages, written from the actual `class-management` components (mapped field-by-field, with real labels):

- **Overview** — the Manage Classes screen: semester selector + toolbar shortcuts (cross-linked to Semester Setup #252), the list columns, the four **statuses** (Live / Paused / Info Only / Draft), and row actions including **Copy** (which creates a draft, great for rolling a class to next term).
- **Creating & editing a class** — the full form, section by section: basic info, the markdown description editor, image upload, schedule (day/time selectors), enrollment settings, **pricing + sliding scale**, additional paid options, instructors, **units** (paths vs Mallards/Mapaches), and the **visibility** toggles + "why can't I publish?" required-field rules.
- **Class groups** — bundling classes at a discount (min 2, savings badge).

## Principles
- Admin audience — **no Firebase/storage/server internals** on the page; preserved in invisible MDX maintainer comments.
- `<Shot>` placeholders throughout (class-list, class-form-*, class-groups, dialogs) for the screenshot automation (#258).

## Verified
`nx run docs:build-pages` exports all pages; cross-links and section anchors (e.g. `…/creating-a-class/#visibility`) resolve under the `/platform` basePath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)