### PR TITLE
docs(content): Semester Setup section (#252)

### DIFF
--- a/apps/docs/content/semester-setup/_meta.js
+++ b/apps/docs/content/semester-setup/_meta.js
@@ -1,0 +1,6 @@
+export default {
+    index: 'Semesters',
+    'info-panel': 'Info panel',
+    'enrollment-messages': 'Enrollment messages',
+    'email-content': 'Confirmation email',
+};

--- a/apps/docs/content/semester-setup/email-content.mdx
+++ b/apps/docs/content/semester-setup/email-content.mdx
@@ -1,0 +1,50 @@
+---
+title: Confirmation email
+---
+
+# Confirmation email content
+
+When a family completes enrollment, they get a confirmation email. You can add
+your own **per-semester content** to it — what to bring, links to handouts, parking
+notes, and so on. The receipt and footer are added automatically.
+
+Open it from **Email Content** on the [Manage Classes](/class-management) toolbar
+(enabled once a semester is selected).
+
+<Shot slug="email-content-editor" caption="The confirmation email content editor with live preview." />
+
+> If a family enrolls in classes across more than one semester in a single
+> checkout, each semester's content gets its own section in the email.
+
+## Writing the content
+
+On the left, the **Content** box is a markdown editor — type what you want added to
+the email (e.g. *What to bring, links to handouts, parking notes…*). It supports
+`**bold**`, `*italic*`, lists, and `[links](url)`.
+
+## Attachments
+
+Use **Upload PDF** to attach files (like a packing list or waiver) to the
+confirmation email. Uploaded files appear in a list, each with a link and a delete
+button. There's no attachment until you add one.
+
+## Live preview
+
+The right side shows a **live preview** of the actual confirmation email — rendered
+with sample enrollment data — so you can see exactly how your content and
+attachments will look before saving.
+
+## Saving
+
+Your changes save with a status indicator at the bottom (*Saving…* → a green
+success message). 
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Route: /admin/classes/management/enrollment-email/:semesterId.
+    Component: EnrollmentEmailContentEditorComponent.
+  - Left: markdown body + PDF attachments (upload/list/delete). Right: live HTML iframe preview.
+  - Per-semester; multi-semester checkout => per-semester sections. Receipt/footer auto-generated.
+  - Attachments stored in Cloud Storage (don't surface). Shipped in #215/#217.
+  - Source: libs/angular/classes/class-management/enrollment-email-content-editor/.
+*/}

--- a/apps/docs/content/semester-setup/enrollment-messages.mdx
+++ b/apps/docs/content/semester-setup/enrollment-messages.mdx
@@ -1,0 +1,45 @@
+---
+title: Enrollment messages
+---
+
+# Enrollment messages
+
+**Enrollment messages** are banners shown at the **top of the enrollment flow** —
+use them for announcements, deadlines, or promotions. Several can be active at
+once. Open the editor from **Enrollment Messages** on the Admin Dashboard
+(`/admin/messages`).
+
+<Shot slug="enrollment-messages" caption="The Enrollment Messages editor." />
+
+> Unlike the info panel and confirmation email, enrollment messages are **not tied
+> to a semester** — they show across the enrollment flow until you turn them off or
+> they expire.
+
+## Adding a message
+
+Click **Add Message**. Each message is a card with:
+
+| Field | What it does |
+| --- | --- |
+| **Active** | Toggle the message on or off without deleting it. |
+| **Text** | The message itself — a markdown editor (`**bold**`, `[link](url)`). |
+| **Severity** | The color/tone: **Info** (blue), **Warning** (amber), **Success** (green), or **Promotional** (yellow). |
+| **Start Date** *(optional)* | When the message should begin showing. |
+| **End Date** *(optional)* | When it should stop — handy for time-limited notices. |
+
+Use the **trash icon** on a card to remove a message.
+
+## Saving
+
+Click **Save All** to save every message at once — you'll see *"Messages saved
+successfully!"* The dates let messages turn themselves on and off, so you can set up
+a promotion ahead of time and leave it.
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Route: /admin/messages. Component: EnrollmentMessagesEditorComponent.
+  - Global (not per-semester). Per-message: active, text (markdown), severity
+    (info/warning/success/promotional), optional start/end dates; per-card delete.
+  - "Save All" persists the whole list (updateEnrollmentMessages).
+  - Source: libs/angular/admin/enrollment-messages/.
+*/}

--- a/apps/docs/content/semester-setup/index.mdx
+++ b/apps/docs/content/semester-setup/index.mdx
@@ -2,24 +2,56 @@
 title: Semester Setup
 ---
 
-# Semester Setup
+# Semesters
 
-> _Stub — full content tracked in [#252](https://github.com/MountainSOLSchool/platform/issues/252)._
+A **semester** is the term families enroll into (e.g. *Fall 2025*). This section
+covers creating and managing semesters, plus the things that shape the enrollment
+experience for a term:
 
-Everything that shapes what families see when a semester opens for enrollment.
+- [Info panel](/semester-setup/info-panel) — the info box on the enrollment page
+- [Enrollment messages](/semester-setup/enrollment-messages) — banners at the top of enrollment
+- [Confirmation email](/semester-setup/email-content) — what's added to the enrollment confirmation email
 
-- **Semesters** — add a semester and set the active one.
-- **Info panel editor** — the highlight boxes / info cards shown on the
-  enrollment page.
-- **Enrollment messages** — info / warning / success / promotional banners at the
-  top of the enrollment flow.
-- **Confirmation email content** — per-semester content for enrollment
-  confirmation emails, with **real-HTML preview, attachments, and admin
-  test-send** ([#217](https://github.com/MountainSOLSchool/platform/pull/217)).
+You manage semesters from the toolbar on the [Manage Classes](/class-management)
+screen.
 
-<Shot slug="info-panel-editor" caption="Editing the enrollment-page info panel." />
+## Add a semester
 
-<Shot slug="enrollment-email-editor" caption="Confirmation email content editor with preview." />
+Click **Add Semester**. Enter a **Semester Name** in the form *Season Year* — e.g.
+*Fall 2025* or *Summer 2026* — and click **Create**. The new semester then appears
+in the **Select Semester** dropdown everywhere.
 
-**Source:** `libs/angular/classes/class-management/info-panel-editor/`,
-`enrollment-email-content-editor/`; `libs/angular/admin/enrollment-messages/`.
+<Shot slug="add-semester" caption="The Add Semester dialog." />
+
+## Manage semesters
+
+Click **Manage Semesters** to control which semesters families can enroll in and to
+tidy up old ones. The dialog has two tabs.
+
+### Active
+
+- **Primary Active Semester** — the default semester for enrollment. Pick the one
+  families should land on.
+- **Additional Enrollable Semesters** — check any *other* semesters you also want
+  open for enrollment (for example, when two terms overlap). Families can enroll in
+  these as well as the primary one.
+
+### Archived
+
+- **Archive Semesters** — click **Archive** next to a semester to hide it from the
+  semester dropdowns. Archiving doesn't delete anything; it just gets old terms out
+  of the way.
+- **Archived Semesters** — click **Unarchive** to bring one back.
+
+<Shot slug="manage-semesters" caption="The Manage Semesters dialog (Active and Archived tabs)." />
+
+> After adding or managing semesters, the screen refreshes so the new state shows
+> everywhere.
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Add Semester / Manage Semesters are dialogs launched from class-list toolbar; reload on save.
+  - Active tab: primary active semester + additional enrollable (active) semesters.
+  - Archived tab: archive/unarchive toggles a flag; hides from dropdowns.
+  - Source: libs/angular/classes/class-management/ (AddSemesterDialog, ActiveSemesterDialog).
+*/}

--- a/apps/docs/content/semester-setup/info-panel.mdx
+++ b/apps/docs/content/semester-setup/info-panel.mdx
@@ -1,0 +1,58 @@
+---
+title: Info panel
+---
+
+# Info panel
+
+The **info panel** is the expandable information box families see at the top of the
+enrollment page for a semester — a good place for program highlights, schedules,
+what-to-bring notes, and the like. It's set per-semester.
+
+Open it from **Info Panel** on the [Manage Classes](/class-management) toolbar
+(it's enabled once you've selected a semester).
+
+<Shot slug="info-panel-editor" caption="The info panel editor." />
+
+## Header settings
+
+| Control | What it does |
+| --- | --- |
+| **Panel active (visible to students)** | Turns the whole panel on or off for families. |
+| **Expanded by default** | Whether the panel starts open or collapsed. |
+| **Title** | The panel heading, e.g. *Summer 2025 Program Information*. |
+| **Subtitle** | A short line under the title, e.g. *Click to expand for details*. |
+| **Gradient** | The panel's background. Pick a preset (Purple Blue, Orange Red, Green Teal, Sunset, Sky Blue, Forest) or paste a custom CSS gradient. |
+
+## Highlight boxes
+
+Short, colored callouts for the most important notes. Click **Add Highlight Box**,
+choose a **Type** — **Info**, **Warning**, **Success**, or **Promotional** (each is
+a different color) — and enter the text. Remove one with its trash icon.
+
+## Info cards
+
+Larger content blocks below the highlights. Click **Add Content Section**, give it a
+heading (e.g. *Schedule & Dates*), and choose a layout:
+
+- **Text** — a paragraph of information.
+- **List** — a bulleted list; use **Add Item** for each point.
+- **Grid** — items arranged in a grid.
+
+Add as many sections as you need; remove one with its trash icon.
+
+## Reusing a previous semester
+
+To start from a past term instead of a blank panel, use **Copy from another
+semester** — pick the semester under **Copy from** and click **Import**, then tweak.
+
+<Shot slug="info-panel-preview" caption="How the info panel appears on the enrollment page." />
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Route: /admin/classes/management/info-panel/:semesterId. Component: InfoPanelEditorComponent (~1700 lines).
+  - Header: active toggle, expandedByDefault, title, subtitle, gradient (6 presets + custom linear-gradient).
+  - Highlight boxes: type info/warning/success/promotional.
+  - Info cards / content sections: type text | list | grid; each with heading + items.
+  - Copy-from-semester imports another semester's panel config.
+  - Source: libs/angular/classes/class-management/info-panel-editor/.
+*/}


### PR DESCRIPTION
Closes #252; part of #260.

Four pages, written from the real components (Add/Manage Semester dialogs, the ~1700-line info-panel editor, the enrollment-messages editor, and the email-content editor):

- **Semesters** — add a semester; **Manage Semesters** (Active: primary + additional enrollable; Archived: archive/unarchive).
- **Info panel** — the enrollment-page info box: header settings + gradient presets, **highlight boxes** (Info/Warning/Success/Promotional), **info cards** (Text/List/Grid), and copy-from-another-semester.
- **Enrollment messages** — global banners: active toggle, markdown, severity, optional start/end dates, per-message delete, Save All. (Noted these are *not* per-semester.)
- **Confirmation email** — per-semester content, PDF attachments, live HTML preview.

Along the way this **corrects two stale audit flags** that the code disproves: enrollment messages *do* have per-message delete, and the email editor *does* have attachments + live preview (#215/#217).

Admin audience — no Firebase/storage internals on the page (kept in invisible MDX maintainer comments). `<Shot>` placeholders throughout. `nx run docs:build-pages` exports all four pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)