### PR TITLE
fix(ci): run e2e_dev on Node 24 to match the regenerated lockfile

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -453,9 +453,15 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                # Pinned 22.22.3: Node 22.23.0 regressed node-fetch keep-alive
-                # (false "Premature close" on concurrent requests) — maple #503.
-                node-version: '22.22.3'
+                # Node 24 to match the rest of the workflow. The repo moved to
+                # Node 24 (#262/#264) and regenerated package-lock.json with
+                # Node 24's npm; the old 22.22.3 pin then broke `npm ci` here
+                # ("Missing ... from lock file") while every Node-24 job passed.
+                # The 22.22.3 pin originally avoided a node-fetch keep-alive
+                # regression backported to Node 22.23.0 (false "Premature close"
+                # on concurrent requests — maple #503); Node 24 carries the fix,
+                # and the Admin-SDK seed's withRetry absorbs any residual blips.
+                node-version: '24'
                 cache: 'npm'
 
             - name: Install dependencies


### PR DESCRIPTION
## Problem
Every merge to `main` is currently failing at **`e2e_dev`** — not a test failure, but `npm ci` erroring with `Missing: @types/node@26.0.1 … from lock file`.

**Cause:** the Node 24 migration (#262/#264) regenerated `package-lock.json` with Node 24's npm, but `e2e_dev` was still pinned to **Node 22.22.3**. Node 22's npm can't `npm ci` the Node-24 lockfile. The other three jobs already run Node 24 and pass — `e2e_dev` is the lone holdout.

This also **blocks the new prod-approval gate** (#235): `approve_prod` requires `e2e_dev` to be green, so no merge can reach prod while e2e is red.

## Fix
Bump `e2e_dev` to `node-version: '24'`, matching the rest of the workflow.

The 22.22.3 pin originally avoided a node-fetch keep-alive regression backported to Node 22.23.0 (false "Premature close"; maple #503). Node 24 is a newer line that carries the fix, and the Admin-SDK seed's `withRetry` already absorbs transient connection blips — so the pin is no longer needed.

## Verify
The next merge's `e2e_dev` should install cleanly and run the deployed-dev suite green again.