### PR TITLE
fix(docs): generate Pagefind search index (fixes broken site search)

### DIFF
--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -43,7 +43,7 @@
             "outputs": ["{projectRoot}/out"],
             "options": {
                 "cwd": "apps/docs",
-                "command": "DOCS_EXPORT=1 npx next build"
+                "command": "DOCS_EXPORT=1 npx next build && npx pagefind --site out --output-subdir _pagefind"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
                 "lint-staged": "^15.0.2",
                 "ng-packagr": "21.2.3",
                 "nx": "22.7.2",
+                "pagefind": "^1.5.2",
                 "postcss": "^8.5.10",
                 "postcss-import": "14.1.0",
                 "postcss-preset-env": "7.5.0",
@@ -148,7 +149,7 @@
                 "typescript": "5.9.3"
             },
             "engines": {
-                "node": "22"
+                "node": "24"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -13836,6 +13837,104 @@
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@pagefind/darwin-arm64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+            "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@pagefind/darwin-x64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+            "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@pagefind/freebsd-x64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+            "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@pagefind/linux-arm64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+            "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@pagefind/linux-x64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+            "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@pagefind/windows-arm64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+            "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@pagefind/windows-x64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+            "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -40659,6 +40758,25 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/pagefind": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+            "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "pagefind": "lib/runner/bin.cjs"
+            },
+            "optionalDependencies": {
+                "@pagefind/darwin-arm64": "1.5.2",
+                "@pagefind/darwin-x64": "1.5.2",
+                "@pagefind/freebsd-x64": "1.5.2",
+                "@pagefind/linux-arm64": "1.5.2",
+                "@pagefind/linux-x64": "1.5.2",
+                "@pagefind/windows-arm64": "1.5.2",
+                "@pagefind/windows-x64": "1.5.2"
             }
         },
         "node_modules/param-case": {

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
         "lint-staged": "^15.0.2",
         "ng-packagr": "21.2.3",
         "nx": "22.7.2",
+        "pagefind": "^1.5.2",
         "postcss": "^8.5.10",
         "postcss-import": "14.1.0",
         "postcss-preset-env": "7.5.0",


### PR DESCRIPTION
Fixes the **"Failed to load search index — Importing a module script failed"** error on the live Admin Guide search.

## Cause
Nextra 4's search dynamically imports `addBasePath("/_pagefind/pagefind.js")`. basePath was fine (it resolves to `/platform/_pagefind/...`), but the static export **never generated the Pagefind bundle**, so that import 404'd.

## Fix
Run Pagefind immediately after the export, in the `build-pages` target:
```
DOCS_EXPORT=1 next build && pagefind --site out --output-subdir _pagefind
```
- Adds `pagefind` as a devDependency (binary comes via optionalDependencies — no blocked install scripts).
- Outputs to `out/_pagefind` — Nextra expects the underscore-prefixed dir; the existing `.nojekyll` already lets GitHub Pages serve underscore dirs (same reason `_next` works).

## Verified
`nx run docs:build-pages` now produces `out/_pagefind/pagefind.js` and indexes all 14 pages. Once merged + deployed, typing in the search box will return results instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)