### PR TITLE
docs(content): Enrollment & Discounts section (#253)

### DIFF
--- a/apps/docs/content/enrollment-discounts/_meta.js
+++ b/apps/docs/content/enrollment-discounts/_meta.js
@@ -1,0 +1,4 @@
+export default {
+    index: 'Enrollments',
+    discounts: 'Discounts',
+};

--- a/apps/docs/content/enrollment-discounts/discounts.mdx
+++ b/apps/docs/content/enrollment-discounts/discounts.mdx
@@ -1,0 +1,73 @@
+---
+title: Discounts
+---
+
+# Discounts
+
+**Manage Discounts** (`/admin/discounts`) is where you create and manage discount
+codes families enter at checkout.
+
+<Shot slug="discount-list" caption="The discounts list with filters." />
+
+## The discount list
+
+Each code is a row showing its **Status** (Active/Inactive), **Code**, **Type**,
+and a plain-language **Details** summary (e.g. *"$10 off"*, *"15% off"*, *"$5 off
+(expires 12/31/2025)"*). The **Actions** column has **Edit** and **Delete**.
+
+Filter with:
+
+- the **Active / Inactive / All** toggle, and
+- the **Type** dropdown (All Types, or one specific type).
+
+If there are no codes yet, a **Create First Discount** button appears.
+
+## Creating or editing a discount
+
+Click **Create Discount** (or **Edit** on a row). Three fields always show:
+
+| Field | Notes |
+| --- | --- |
+| **Discount Code** | What families type at checkout, e.g. `EARLYBIRD25`. Saved in UPPERCASE and must be unique — you'll get *"Code … is already in use"* if it clashes. |
+| **Type** | Picks the kind of discount (below). The rest of the form changes to match. |
+| **Active** | Whether the code can be used right now. Toggle this off to disable a code without deleting it. |
+
+<Shot slug="discount-form" caption="The create discount form." />
+
+### Discount types
+
+| Type | What it does | Fields you fill in |
+| --- | --- | --- |
+| **Fixed Amount Off** | A flat dollar amount off | **Amount ($)** |
+| **Percentage Off** | A percent off the total | **Percent (%)** (0–100) |
+| **Fixed Amount Off (with Expiry)** | A flat amount that stops working after a date | **Amount ($)**, **Expiry Date** |
+| **Percentage Off Specific Classes** | A percent off, but only on certain classes | **Percent (%)**, **Class or Group IDs** |
+| **Free Classes** | Makes specific classes free | **Class or Group IDs** |
+| **Buy X Class Type, Get % Off** | A percent off once they buy enough of certain class types | **Percent (%)**, **Class Types**, **Minimum Classes** |
+
+> **Class or Group IDs** and **Class Types** are entered as comma-separated values
+> (e.g. `id1, id2` or `Mountain, Water`). To find a class's ID, open the class on
+> [Manage Classes](/class-management) and use **View details** — the Class ID is
+> shown there. Double-check IDs, since a typo means the discount silently won't
+> apply.
+
+Click **Create Discount** / **Update Discount** to save; you'll get a confirmation
+and return to the list.
+
+## Deleting a discount
+
+Click the **Delete** (trash) icon on a row. A dialog asks you to confirm —
+*"Are you sure you want to delete the discount code **CODE**? This action cannot be
+undone."* Click **Delete** to remove it, or disable it instead by editing and
+turning **Active** off.
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Routes: /admin/discounts, .../create, .../edit/:id. Components: DiscountListComponent,
+    DiscountFormComponent, ConfirmDeleteDialogComponent.
+  - Types (value): amount, percent, amount-before-date, classes-percent, free-classes,
+    buy-x-class-type-percent. Code uppercased + unique-checked.
+  - Class/Group IDs + Class Types are raw comma-separated text (no picker) — IDs visible
+    in the class View Details dialog.
+  - Source: libs/angular/admin/discounts/.
+*/}

--- a/apps/docs/content/enrollment-discounts/index.mdx
+++ b/apps/docs/content/enrollment-discounts/index.mdx
@@ -1,25 +1,69 @@
 ---
-title: Enrollment & Discounts
+title: Enrollments
 ---
 
-# Enrollment & Discounts
+# Enrollments
 
-> _Stub — full content tracked in [#253](https://github.com/MountainSOLSchool/platform/issues/253)._
+The **Enrollments** screen (`/admin/enrollments`, or **Enrollments** on the
+dashboard) lists everyone enrolled, and is where you **revoke and refund**. For
+discount codes, see [Discounts](/enrollment-discounts/discounts).
 
-View enrollments and manage discount codes.
+<Shot slug="admin-enrollments" caption="The admin Enrollments table." />
 
-- **View enrollments** (`/admin/enrollments`) — table of enrollments with class
-  names, applied discounts, and refund status.
-- **Revoke & refund** — revoke an enrollment with a **Braintree refund**,
-  including **partial revocation with refund calculation**
-  ([#210](https://github.com/MountainSOLSchool/platform/pull/210)–[#213](https://github.com/MountainSOLSchool/platform/pull/213)).
-- **Discounts** (`/admin/discounts`) — create/edit/delete codes across several
-  types (fixed, percentage, expiring, class-specific, free-class, buy-X-get-%),
-  with active/inactive filtering.
+## The enrollments table
 
-<Shot slug="admin-enrollments" caption="Admin enrollments table." />
+Each row is one enrollment:
 
-<Shot slug="discount-form" caption="Creating a discount code." />
+| Column | What it shows |
+| --- | --- |
+| **Student Name** | The enrolled student |
+| **Date** | When they enrolled |
+| **Classes** | The classes in the enrollment |
+| **Final Cost** | Total paid after any discounts |
+| **Status** | **Enrolled**, or **Revoked** (shown in red) |
+| **Discount columns** | If discounts were applied, each one's name and amount |
 
-**Source:** `libs/angular/admin/enrollments/`,
-`libs/angular/admin/discounts/`.
+- **Sort** by clicking any column header.
+- **Pages** of 20 by default (5/10/20 options).
+- **Export to CSV** (top right) downloads the table as `enrollments.csv`.
+- Revoked enrollments appear dimmed.
+
+## Revoke & refund
+
+To cancel an enrollment (in whole or part) and issue a refund, click **Revoke &
+Refund** in the row's Actions. The button only shows for active enrollments.
+
+<Shot slug="revoke-refund-dialog" caption="The Revoke Enrollment dialog with refund calculation." />
+
+In the **Revoke Enrollment** dialog:
+
+1. **Choose which classes to revoke.** Each class in the enrollment has a
+   checkbox — tick the ones to cancel. You can revoke **some** classes (partial)
+   or **all** of them (full).
+2. **Review the refund.** As you check classes, a **Refund amount** is calculated
+   automatically. A message confirms what will happen — *"All classes selected —
+   enrollment will be fully revoked"* or *"Student will remain enrolled in N
+   class(es)."*
+3. **Adjust if needed.** The refund amount is an editable field — you can change it
+   before confirming (useful when the refund should differ from the automatic
+   amount).
+4. Click **Revoke & Refund** to process, or **Cancel** to back out. The button is
+   disabled until at least one class is selected and the amount has finished
+   calculating.
+
+### If a refund fails
+
+If something goes wrong, a red banner appears warning that **the refund may not
+have gone through** — don't simply retry, because you could double-refund. Verify
+the payment status first; if you're unsure, contact **david@mountainsol.org**
+before trying again. Dismiss the banner with **Dismiss**.
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Route: /admin/enrollments. Component: EnrollmentsComponent.
+  - Revoke dialog: per-class checkboxes; previewPartialRevoke gives suggested refund;
+    refundAmount editable; full vs partial messaging; revokeEnrollment(enrollmentId,
+    classIdsToRevoke, refundAmount).
+  - Error copy mentions Braintree/unsettled txns — softened here to "verify / contact david".
+  - Source: libs/angular/admin/enrollments/.
+*/}


### PR DESCRIPTION
Closes #253; part of #260.

Two pages, written from the real `admin/enrollments` and `admin/discounts` components:

- **Enrollments** — the table (columns, CSV export, sort/paging) and the **Revoke & Refund** flow: per-class checkboxes (partial vs full), automatic refund calculation, the **editable** refund amount, and the failure path (verify before retrying — don't double-refund).
- **Discounts** — the list + Active/Inactive/All and Type filters, the create/edit form, and **all six discount types** with their type-specific fields. Includes the honest caveat that **Class/Group IDs** are raw comma-separated values, with a pointer to find a class's ID via **View details**. Plus delete-vs-disable.

Admin audience — the in-app "check Braintree" error wording is softened to "verify / contact david@mountainsol.org"; technical specifics stay in invisible MDX maintainer comments. `nx run docs:build-pages` exports both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)