### PR TITLE
docs(content): Students & Rosters section (#254)

### DIFF
--- a/apps/docs/content/students-rosters/_meta.js
+++ b/apps/docs/content/students-rosters/_meta.js
@@ -1,0 +1,5 @@
+export default {
+    index: 'Student info sheets',
+    reports: 'Class forms & contacts',
+    't-shirts': 'T-shirt sizes',
+};

--- a/apps/docs/content/students-rosters/index.mdx
+++ b/apps/docs/content/students-rosters/index.mdx
@@ -2,24 +2,49 @@
 title: Students & Rosters
 ---
 
-# Students & Rosters
+# Student information sheets
 
-> _Stub — full content tracked in [#254](https://github.com/MountainSOLSchool/platform/issues/254)._
+The **Student Info Sheets** screen (`/admin/students`) is a searchable directory of
+every student, with a printable **emergency information sheet** for each. This
+section also covers [Class forms & contacts](/students-rosters/reports) and
+[T-shirt sizes](/students-rosters/t-shirts).
 
-The read/report views for day-to-day operations.
+<Shot slug="student-info-table" caption="The Student Information Sheets directory." />
 
-- **Student information** (`/admin/students`) — roster table and full student
-  profiles (age, school, contact, allergies & health notes, with a
-  life-threatening-allergy flag).
-- **Reports & printouts** (`/admin/report`) — per-semester class forms with
-  student counts, downloadable forms, and copy-all-emails for a class.
-- **T-shirts** (`/admin/t-shirts`) — size selections per student and the
-  size-count summary for ordering.
+## The directory
 
-<Shot slug="student-info-table" caption="Admin student information table." />
+The top shows the **Total Students** count and a **search box** — type to filter by
+name, school, or email.
 
-<Shot slug="tshirt-summary" caption="T-shirt size summary for a semester." />
+Each student is a row:
 
-**Source:** `libs/angular/admin/students/`,
-`libs/angular/admin/class-printouts/`,
-`apps/enrollment-portal/src/app/tshirts-component/`.
+| Column | What it shows |
+| --- | --- |
+| **Name** | *Last, First* |
+| **Age** | Calculated from birth date |
+| **School** | The student's school |
+| **Contact** | Email and phone |
+| *(flag)* | A red **Life-Threatening Allergies** tag when applicable |
+| *(action)* | **View Info Sheet** |
+
+Sort by clicking a column header; page through 25 at a time (5/10/25/50 options).
+
+> The **Life-Threatening Allergies** tag is a quick visual warning — those students
+> have flagged severe allergies in their info.
+
+## The emergency info sheet
+
+Click **View Info Sheet** to open a student's full sheet — their emergency and
+health information, formatted for printing. Use the **Print** button to print it
+(or save as PDF from the print dialog) to take to class or keep on file.
+
+<Shot slug="student-info-sheet" caption="A student's printable emergency info sheet." />
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Route: /admin/students. Components: StudentInfoTableViewComponent, StudentInfoDisplayComponent.
+  - Columns: name (last,first), age, school, contact (email/phone), flags
+    (hasLifeThreateningAllergies), actions (View Info Sheet -> dialog with iframe + Print).
+  - Search filters firstName/lastName/school/email. Paginator 25 (5/10/25/50).
+  - Source: libs/angular/admin/students/.
+*/}

--- a/apps/docs/content/students-rosters/reports.mdx
+++ b/apps/docs/content/students-rosters/reports.mdx
@@ -1,0 +1,32 @@
+---
+title: Class forms & contacts
+---
+
+# Class forms & contacts
+
+The **Class Forms and Contacts** screen (`/admin/report`) gives you, per class, the
+printable forms and the contact emails you need to run the term. Pick the term from
+the **Semester** dropdown at the top.
+
+<Shot slug="class-forms-contacts" caption="The Class Forms and Contacts screen." />
+
+Each class is a row showing its **Name**, **# Enrolled Students**, and **Start** /
+**End** dates, with two buttons:
+
+| Button | What it does |
+| --- | --- |
+| **View Forms** | Opens the class's forms (the roster / sign-in and related printouts) to view, print, or save. |
+| **View Emails** | Opens the list of enrolled students' contact emails for that class — handy for sending a class-wide message. |
+
+Sort by any column header to find a class quickly.
+
+> Use **View Emails** to grab the whole class's email list in one go, rather than
+> copying addresses one student at a time.
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Route: /admin/report. Component: ClassPrintoutsViewComponent.
+  - Columns: title, enrolledCount, start, end; actions View Forms (downloadClick ->
+    download-class-forms.service) and View Emails (copyEmailsClick -> copy-class-emails.service / class-emails dialog).
+  - Source: libs/angular/admin/class-printouts/.
+*/}

--- a/apps/docs/content/students-rosters/t-shirts.mdx
+++ b/apps/docs/content/students-rosters/t-shirts.mdx
@@ -1,0 +1,28 @@
+---
+title: T-shirt sizes
+---
+
+# T-shirt sizes
+
+The **T-shirt Sizes** screen (`/admin/t-shirts`) shows the shirt sizes students
+picked, so you can place an order. Choose the term from the **Semester** dropdown.
+
+<Shot slug="tshirt-sizes" caption="The T-shirt sizes screen: size counts and per-student list." />
+
+## Size Counts
+
+A summary table of **Shirt Size** and **Count** — how many of each size to order for
+the semester.
+
+## Students
+
+Below that, a per-student list — **Last Name**, **First Name**, and **Shirt Size** —
+so you can see exactly who chose what. Both tables sort by clicking a column header.
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Route: /admin/t-shirts. Component: TshirtsComponent.
+  - Size Counts table (size, count) + Students table (lastName, firstName, size),
+    scoped to selected semester.
+  - Source: apps/enrollment-portal/src/app/tshirts-component/.
+*/}


### PR DESCRIPTION
Closes #254; part of #260.

Three pages, from the real `admin/students`, `admin/class-printouts`, and tshirts components:

- **Student info sheets** — the searchable directory (Name/Age/School/Contact, the **Life-Threatening Allergies** flag) and the printable per-student **emergency info sheet** (View Info Sheet → Print/save PDF).
- **Class forms & contacts** — per class, **View Forms** (roster/sign-in printouts) and **View Emails** (the class's contact list), scoped by semester.
- **T-shirt sizes** — the **Size Counts** summary for ordering, plus the per-student list.

`nx run docs:build-pages` exports all three. `<Shot>` placeholders throughout; admin audience, maintainer notes in invisible comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)