### PR TITLE
fix(ci): e2e_dev on Node 22.22.3 runtime + npm 11 (fix seed Premature close)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -459,19 +459,27 @@ jobs:
                   service_account: 'github-deployer@mountain-sol-platform-dev.iam.gserviceaccount.com'
                   create_credentials_file: true
 
+            # This job is split-brained on purpose. The Node RUNTIME stays
+            # 22.22.3 because Node 22.23.0+ AND Node 24 carry an http.Agent
+            # keep-alive regression (nodejs/node#63989) that makes the Admin-SDK
+            # seed's sts.googleapis.com token fetch fail with "Premature close" —
+            # systematically, every withRetry attempt — sinking the suite at
+            # seed (maple #503). But the repo moved to Node 24 (#262/#264) and
+            # regenerated package-lock.json with Node 24's npm (11.x), which
+            # Node 22's bundled npm 10 can't `npm ci` ("Missing … from lock
+            # file"). So we run on the keep-alive-safe Node 22.22.3 runtime and
+            # upgrade npm to 11 (next step) just for the install. npm version
+            # governs lockfile parsing; the Node runtime governs the http
+            # behavior — decoupling them satisfies both. Revisit (collapse to a
+            # single Node 24) once nodejs/node#63989 is fixed upstream.
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                # Node 24 to match the rest of the workflow. The repo moved to
-                # Node 24 (#262/#264) and regenerated package-lock.json with
-                # Node 24's npm; the old 22.22.3 pin then broke `npm ci` here
-                # ("Missing ... from lock file") while every Node-24 job passed.
-                # The 22.22.3 pin originally avoided a node-fetch keep-alive
-                # regression backported to Node 22.23.0 (false "Premature close"
-                # on concurrent requests — maple #503); Node 24 carries the fix,
-                # and the Admin-SDK seed's withRetry absorbs any residual blips.
-                node-version: '24'
+                node-version: '22.22.3'
                 cache: 'npm'
+
+            - name: Upgrade npm to match the Node-24 lockfile
+              run: npm install -g npm@11
 
             - name: Install dependencies
               run: npm ci


### PR DESCRIPTION
## Problem
After #272 moved `e2e_dev` to Node 24 (to fix `npm ci` against the Node-24 lockfile), the job still fails — now at the **Admin-SDK seed**: every `withRetry` attempt dies with `sts.googleapis.com/v1/token: Premature close`. That's the node-fetch keep-alive regression (nodejs/node#63989) the original `22.22.3` pin existed to avoid — and it turns out Node 24 carries it too.

So neither single version works:
- **Node 22.22.3** → `npm ci` can't read the npm-11 lockfile (`Missing … from lock file`)
- **Node 24** → `npm ci` works, but the seed's STS fetch fails "Premature close"

This keeps `e2e_dev` red on every merge, which blocks the `approve_prod` gate (it needs `e2e_dev` green).

## Fix
**Decouple runtime from package manager:** run on the keep-alive-safe **Node 22.22.3** runtime, but `npm install -g npm@11` before `npm ci` so npm understands the Node-24-generated lockfile. The npm version governs lockfile parsing; the Node runtime governs http/keep-alive behavior — splitting them satisfies both.

Collapse back to a single Node 24 once nodejs/node#63989 is fixed upstream.

## Validation
Dispatched this branch (`deploy_all`): `deploy_hosting_dev` ✅ → **`e2e_dev` ✅** (npm ci clean, seed completes, suite passes). `approve_prod`/prod jobs correctly skipped on a non-merge dispatch.