### PR TITLE
docs(content): Medic section + live portal links (#255)

### DIFF
--- a/apps/docs/components/Portal.tsx
+++ b/apps/docs/components/Portal.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react';
+
+// Base URL of the live enrollment portal. Override via NEXT_PUBLIC_PORTAL_BASE
+// if the domain ever changes.
+const PORTAL_BASE =
+    process.env.NEXT_PUBLIC_PORTAL_BASE ?? 'https://enrollment.mountainsol.org';
+
+export interface PortalProps {
+    /** Route on the live portal, e.g. "/admin/classes/management". */
+    path: string;
+    /** Link text. Defaults to the path. */
+    children?: ReactNode;
+}
+
+/**
+ * Links to a real screen in the live enrollment portal, opening in a new tab so
+ * the guide stays put. Usage in MDX (registered globally, no import needed):
+ *   <Portal path="/admin/classes/management">Manage Classes</Portal>
+ */
+export function Portal({ path, children }: PortalProps) {
+    return (
+        <a
+            href={`${PORTAL_BASE}${path}`}
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            {children ?? path}
+        </a>
+    );
+}
+
+export default Portal;

--- a/apps/docs/content/medic/_meta.js
+++ b/apps/docs/content/medic/_meta.js
@@ -1,0 +1,4 @@
+export default {
+    index: 'Medic classes',
+    enrollments: 'Medic enrollments',
+};

--- a/apps/docs/content/medic/enrollments.mdx
+++ b/apps/docs/content/medic/enrollments.mdx
@@ -1,0 +1,32 @@
+---
+title: Medic enrollments
+---
+
+# Medic enrollments
+
+The <Portal path="/medic/admin/enrollments">Medic Enrollments</Portal> screen lists
+everyone enrolled in Medic classes. You can also reach a single class's enrollments
+from the **View Enrollments** (people) icon on the
+[Medic classes](/medic) list.
+
+<Shot slug="medic-enrollments" caption="The Medic enrollments screen." />
+
+Each row shows the **Student Name**, **Email**, **Class**, **Amount**,
+**Transaction ID**, and **Date**.
+
+Two controls at the top:
+
+- **Filter by Class** — narrow to a single Medic class, or **All Classes**.
+- **Show Archived Classes** — include classes that have been archived in the filter
+  list.
+
+If nothing matches, you'll see *"No enrollments found."*
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Routes: /medic/admin/enrollments and /medic/admin/classes/enrollments/:classId.
+    Component: MedicAdminEnrollmentsComponent.
+  - Columns: studentName, studentEmail, className, amount, transactionId, timestamp.
+    Filter by class + Show Archived Classes toggle.
+  - Source: libs/angular/medic/admin/.
+*/}

--- a/apps/docs/content/medic/index.mdx
+++ b/apps/docs/content/medic/index.mdx
@@ -2,21 +2,68 @@
 title: Medic Admin
 ---
 
-# Medic Admin
+# Medic classes
 
-> _Stub — full content tracked in [#255](https://github.com/MountainSOLSchool/platform/issues/255)._
+The **Medic program** has its own separate admin area at
+<Portal path="/medic/admin/classes">/medic/admin</Portal>, for managing Medic
+classes and their enrollments. It requires **Medic admin** access (see
+[Admin access & roles](/getting-started/admin-access)) and works independently of
+the youth-program [Class Management](/class-management).
 
-A separate, parallel admin area for the Medic program, gated by `medicAdmin`
-(distinct from full `admin`).
+It's also simpler than youth classes — no units, images, or sliding scale; just
+the essentials below.
 
-- **Medic class list** (`/medic/admin`) — create/view classes; archived toggle.
-- **Create or edit a Medic class** — name, description, cost, location,
-  date/time, capacity.
-- **Medic enrollments** — view enrollments (student, email, transaction, amount,
-  status); filter by class; show archived.
+<Shot slug="medic-class-list" caption="The Medic Classes list." />
 
-<Shot slug="medic-class-list" caption="Medic admin class list." />
+## The Medic classes list
 
-<Shot slug="medic-enrollments" caption="Medic enrollments view." />
+The <Portal path="/medic/admin/classes">Medic Classes</Portal> screen lists each
+class with its **Name**, **Date & Time**, **Cost**, **Enrolled** (count / max), and
+**Status**. Each row has **Edit** (pencil) and **View Enrollments** (people)
+actions.
 
-**Source:** `libs/angular/medic/admin/`.
+- **Show Archived** — toggle on to include archived classes (hidden by default).
+- **New Class** — opens the blank class form.
+
+### Statuses
+
+| Status | Meaning |
+| --- | --- |
+| **Draft** | Not yet visible to families |
+| **Published** | Live and enrollable |
+| **Archived** | Retired and hidden (toggle **Show Archived** to see) |
+
+## Creating or editing a Medic class
+
+Click **New Class** (or **Edit** on a row) to open the form:
+
+| Field | Notes |
+| --- | --- |
+| **Class Name** | Required. |
+| **Description** | Free text. |
+| **Cost ($)** | Required; must be greater than 0. |
+| **Status** | **Draft** or **Published** (and **Archived** when editing). |
+| **Location** | Where it meets. |
+| **Date** | Free text, e.g. *March 15, 2026*. |
+| **Time** | Free text, e.g. *9:00 AM - 3:00 PM*. |
+| **Min / Max Students** | Capacity for the class. |
+
+> Unlike youth classes, the **Date** and **Time** here are plain text you type —
+> there's no calendar or day picker.
+
+Click **Create Class** / **Update Class** to save (you'll get a confirmation and a
+**Back to Classes** link), or **Cancel** to discard.
+
+<Shot slug="medic-class-form" caption="The Medic class form." />
+
+{/*
+  Doc-maintainer notes (not shown to readers):
+  - Routes: /medic/admin -> classes; classes/create; classes/edit/:id;
+    classes/enrollments/:classId; enrollments. Guard: userGuard + medicAdminGuard.
+  - List columns: name, date&time, cost, enrolled (count/max), status chip
+    (draft/published/archived), actions (edit, view enrollments). Show Archived toggle.
+  - Form fields: name (req), description, cost (req >0), status (draft/published;
+    archived only when editing), location, date (free text), time (free text),
+    minStudents, maxStudents.
+  - Source: libs/angular/medic/admin/.
+*/}

--- a/apps/docs/mdx-components.js
+++ b/apps/docs/mdx-components.js
@@ -1,14 +1,18 @@
 import { useMDXComponents as getThemeComponents } from 'nextra-theme-docs';
 import { Shot } from './components/Shot';
+import { Portal } from './components/Portal';
 
 const themeComponents = getThemeComponents();
 
-// `Shot` is registered globally so every MDX page can drop a screenshot
-// placeholder with `<Shot slug="..." caption="..." />` — no per-file import.
+// `Shot` and `Portal` are registered globally so every MDX page can use
+// `<Shot slug="..." />` (screenshot placeholder) and
+// `<Portal path="/admin/...">…</Portal>` (link to the live portal) without
+// a per-file import.
 export function useMDXComponents(components) {
     return {
         ...themeComponents,
         Shot,
+        Portal,
         ...components,
     };
 }


### PR DESCRIPTION
Closes #255; part of #260. Also introduces **live portal links** (your request).

## Live portal links
New `<Portal path="…">` component (registered globally alongside `<Shot>`) links a documented screen straight to the **live tool** at `enrollment.mountainsol.org`, opening in a new tab — e.g. `<Portal path="/admin/classes/management">Manage Classes</Portal>`. The base URL is centralized (overridable via `NEXT_PUBLIC_PORTAL_BASE`). Used throughout the Medic pages here; I'll **retrofit the earlier sections** (#250–#254) in a focused follow-up PR.

## Medic content
From the real `medic/admin` components:
- **Medic classes** — the list (Show Archived; statuses Draft/Published/Archived) and the create/edit form. Calls out that Medic is **simpler** than youth classes: free-text Date/Time, no units/images/sliding scale.
- **Medic enrollments** — the table (student/email/class/amount/transaction/date) with filter-by-class and show-archived.

Verified: `nx run docs:build-pages` exports the pages and `<Portal>` renders `href="https://enrollment.mountainsol.org/medic/admin/classes"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)