### PR TITLE
fix(enrollment-portal): center CDK dialogs (load CDK overlay CSS)

### DIFF
--- a/apps/enrollment-portal/project.json
+++ b/apps/enrollment-portal/project.json
@@ -25,6 +25,7 @@
                     }
                 ],
                 "styles": [
+                    "node_modules/@angular/cdk/overlay-prebuilt.css",
                     "apps/enrollment-portal/src/design-tokens.scss",
                     "apps/enrollment-portal/src/custom-theme.scss",
                     "apps/enrollment-portal/src/styles.css",


### PR DESCRIPTION
## The bug
Every CDK dialog in the portal — **Add Semester, Manage Semesters, Copy Class, Class Detail, Class Group form, Revoke & Refund, delete confirmations** — renders in the **top-left corner with no backdrop** (and the raised button looks unstyled). Surfaced while driving the live dev admin UI.

## Cause
The Material 3 theme is set up with `mat.theme()` in `custom-theme.scss`, but the app **never loads the CDK overlay *structural* CSS** (`@angular/cdk/overlay-prebuilt.css`, normally pulled in by `mat.core()` in older setups). That stylesheet provides `.cdk-global-overlay-wrapper` (flex-centering) and `.cdk-overlay-backdrop`. Without it:
- **Globally-centered overlays (dialogs)** have no positioning → fall back to top-left, no backdrop.
- **Connected overlays (dropdowns, menus, selects)** anchor to their trigger element and keep working — which is why only dialogs looked broken.

Likely latent since the PrimeNG→Angular Material migration (#222).

## Fix
Add `node_modules/@angular/cdk/overlay-prebuilt.css` to the `styles` array in `apps/enrollment-portal/project.json` (applies to all build configurations). Purely structural CSS — coexists with the M3 theme.

## Verification
Build is gated by CI. Visual centering will confirm on the dev deploy after merge (this was found on dev). No app code changed — one build-config line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)