### PR TITLE
fix(enrollment-portal): center CDK dialogs (CDK 21 popover wrapper)

### DIFF
--- a/apps/enrollment-portal/src/custom-theme.scss
+++ b/apps/enrollment-portal/src/custom-theme.scss
@@ -31,6 +31,16 @@ body {
     font-family: 'EB Garamond', Georgia, serif !important;
 }
 
+// Center CDK dialogs. CDK 21's popover-based global overlays don't apply the
+// GlobalPositionStrategy's centering to the wrapper, so dialogs land top-left
+// even with the overlay structural CSS loaded. Scoped via :has() to dialog
+// overlays only, so connected overlays (dropdowns/menus) and other global
+// overlays (snackbars/bottom-sheets) keep their own positioning.
+.cdk-global-overlay-wrapper:has(.cdk-dialog-container) {
+    justify-content: center;
+    align-items: center;
+}
+
 // Match prior PrimeNG button typography: 14px / 400.
 // Material's default reads --mat-button-{variant}-label-text-{size,weight}, falling
 // back to .875rem / 500 — at our 14px root that renders as 12.25px / 500.


### PR DESCRIPTION
Follow-up to #279 — the dialog **still rendered top-left** after that merge, so this completes the fix.

## Why #279 wasn't enough
#279 loaded `overlay-prebuilt.css`, which correctly made `.cdk-overlay-container` `position: fixed` (it was unstyled before). But in **CDK 21**, overlays use the browser **Popover API** (`.cdk-overlay-popover`, `popover="manual"`), and the `GlobalPositionStrategy`'s centering — which should set `justify-content`/`align-items: center` inline on the wrapper — **isn't being applied**. So the flex wrapper defaulted to top-left.

Verified live on dev via DevTools: the wrapper had no inline centering; injecting the rule below moved the pane to center.

## Fix
A scoped CSS rule in `custom-theme.scss`:
```css
.cdk-global-overlay-wrapper:has(.cdk-dialog-container) {
  justify-content: center;
  align-items: center;
}
```
`:has(.cdk-dialog-container)` limits it to **dialog** overlays, so:
- connected overlays (dropdowns/menus, `.cdk-overlay-connected-position-bounding-box`) are untouched, and
- other global overlays (snackbars/bottom-sheets) keep their own inline positioning.

Affects every CDK dialog (Add Semester, Manage Semesters, Copy Class, Class Detail, Class Group, Revoke & Refund, delete confirms). Global stylesheet, ~150 bytes — no component-style-budget impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)