### PR TITLE
fix(ci): disconnect Nx Cloud (org disabled, hard-failing all CI)

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -175,5 +175,5 @@
             }
         }
     ],
-    "nxCloudId": "684c4ca4c2aab9206632cfd3"
+    "neverConnectToCloud": true
 }


### PR DESCRIPTION
## Problem — repo-wide CI outage
Every CI job (PR checks **and** the merge pipeline) is failing in ~1 minute with:

```
NX   Nx Cloud: Workspace is unable to be authorized. Exiting run.
This Nx Cloud organization has been disabled due to exceeding the FREE plan.
```

`nx.json` carries `nxCloudId`, so `nx` tries to reach the (now-disabled) Nx Cloud org and **hard-exits before running anything**. This blocks build, lint, unit, e2e, Firebase integration, Storybook — and the `e2e_dev` gate, which in turn blocks the whole prod-promotion pipeline (#235/#236).

## Fix
Replace `nxCloudId` with `neverConnectToCloud: true`. `nx` then runs locally with its own cache and never blocks on cloud auth.

Verified locally: `npx nx show projects` runs clean (no "unable to be authorized") with the change. This PR's own checks should go green, demonstrating CI is unblocked.

## Reversible
If you later upgrade the Nx Cloud plan, re-enable with `nx connect` (restores distributed caching). For a repo this size, local caching is sufficient meanwhile.