### PR TITLE
fix: don't emit an undefined semester (fixes Add Semester dialog) (#284)

### DIFF
--- a/libs/angular/classes/class-management/src/lib/components/class-list/class-list.component.ts
+++ b/libs/angular/classes/class-management/src/lib/components/class-list/class-list.component.ts
@@ -474,7 +474,7 @@ export class AdminClassListComponent {
     );
 
     readonly selectedSemesterId = linkedSignal<string>(() => {
-        const sems = this.semesters();
+        const sems = this.semesters().filter((s): s is Semester => !!s);
         const queryParamSemesterId = this.#semesterIdFromQuery();
         if (sems.length === 0) return '';
         // Use query param if valid, otherwise default to first semester

--- a/libs/angular/classes/class-semester-list/src/lib/semester-list/services/classes-semester-list.service.ts
+++ b/libs/angular/classes/class-semester-list/src/lib/semester-list/services/classes-semester-list.service.ts
@@ -66,7 +66,10 @@ export class ClassesSemesterListService {
                             (semester) => semester.id === r.activeSemesterId
                         ) ?? nonArchivedSemesters[0];
                     return [
-                        currentSemester,
+                        // When there are no non-archived semesters,
+                        // currentSemester is undefined — don't emit a list with
+                        // an undefined entry (consumers read `.id` on it).
+                        ...(currentSemester ? [currentSemester] : []),
                         ...this.sortSemesters(
                             nonArchivedSemesters
                                 .filter((semester) => !!semester.name)


### PR DESCRIPTION
Fixes **#284** — and the root cause turned out to be a single `.id`-on-undefined in the semester list.

## Root cause
`ClassesSemesterListService.getAllSemestersWithCurrentFirst()`:
```ts
const currentSemester =
  nonArchivedSemesters.find(s => s.id === r.activeSemesterId)
  ?? nonArchivedSemesters[0];          // undefined when the list is empty
return [currentSemester, ...sorted];   // => [undefined]
```
When there are no non-archived semesters, it returned **`[undefined]`**.

The Manage Classes `selectedSemesterId` linkedSignal only guards `if (sems.length === 0)`, so `[undefined]` (length 1) slipped past it and `sems.some(s => s.id === …)` did **`undefined.id`** → `TypeError: Cannot read properties of undefined (reading 'id')` on every signal recompute. That poisoned the reactive graph on the page, which is exactly why (from #284):
- the Add Semester dialog's form-field rendered **unstyled** (its render aborted), and
- **Create** fired no `createSemester` request (the `saving` signal change re-triggered the throwing computed).

Captured the live stack trace (`producerRecomputeValue` → `Object.source` reading `id`) to pin it down.

## Fix
- **Service:** omit the undefined current semester — `...(currentSemester ? [currentSemester] : [])`.
- **Consumer (class-list):** defensively `.filter((s): s is Semester => !!s)` before reading `.id`, so a stray undefined can never throw again.

`nx run enrollment-portal:build` passes; typecheck + lint pass.

After this deploys, the Add Semester dialog should render its outlined input and successfully create a semester — unblocking the documentation screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)