### PR TITLE
fix(enrollment-portal): center button labels — hide save-spinners (#288)

### DIFF
--- a/apps/enrollment-portal/src/custom-theme.scss
+++ b/apps/enrollment-portal/src/custom-theme.scss
@@ -172,6 +172,14 @@ body {
     --mdc-circular-progress-active-indicator-color: var(--sol-primary, #006633);
 }
 
+// Button save-spinners are toggled with [hidden], but Material sets
+// .mat-mdc-progress-spinner { display: block }, which overrides the `hidden`
+// attribute — so the 20px spinner still occupies space and pushes the button
+// label off-center. Force it to actually hide when [hidden] (#288, from #283).
+.mat-mdc-button-base .mat-mdc-progress-spinner[hidden] {
+    display: none !important;
+}
+
 // Tabs — match prior PrimeNG p-tabView styling
 // (14px bold labels, SOL green active text, generous tab body padding)
 .mat-mdc-tab-group,


### PR DESCRIPTION
Fixes **#288** — filled/raised primary buttons rendered their text off-center.

## Cause
Regression from #283. The always-present `<mat-spinner [hidden]="!saving()">` wasn't actually hidden — `.mat-mdc-progress-spinner` sets `display: block`, which overrides the `hidden` attribute, so a **20px ghost spinner** kept its layout space and shoved the label off-center.

## Fix
One scoped rule in `custom-theme.scss`:
```css
.mat-mdc-button-base .mat-mdc-progress-spinner[hidden] { display: none !important; }
```
Fixes every affected button at once (add/active semester, copy class, class group, class form, discount form, enrollment messages, info-panel import, medic class form).

Verified live via DevTools: hidden spinner → `display: none`, width 0, label span centered (`spanCenterOffset: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)