### PR TITLE
fix(docs): style <Portal> links (rendered undecorated)

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -29,3 +29,24 @@
     font-size: 0.8em;
     opacity: 0.6;
 }
+
+/* <Portal> renders a raw <a>, which Tailwind's preflight leaves undecorated
+   (inherits body color, no underline). Style it to match Nextra's content
+   links, with an external-link marker since it opens the live portal. */
+.sol-portal-link {
+    color: #1a56db;
+    text-decoration: underline;
+    text-decoration-thickness: from-font;
+    text-underline-position: from-font;
+}
+.sol-portal-link:hover {
+    text-decoration: none;
+}
+.sol-portal-link::after {
+    content: ' ↗';
+    font-size: 0.85em;
+    opacity: 0.7;
+}
+:is(.dark, [data-theme='dark']) .sol-portal-link {
+    color: #7cc4ff;
+}

--- a/apps/docs/components/Portal.tsx
+++ b/apps/docs/components/Portal.tsx
@@ -20,6 +20,7 @@ export interface PortalProps {
 export function Portal({ path, children }: PortalProps) {
     return (
         <a
+            className="sol-portal-link"
             href={`${PORTAL_BASE}${path}`}
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
On the live docsite, the **`<Portal>` links** (to the live enrollment portal) render with no color or underline — they inherit the body text color, so they look like plain text and are easy to miss.

## Cause
`<Portal>` renders a **raw `<a>`**, which bypasses Nextra's styled link component. Tailwind's preflight then resets it (`color: inherit`, `text-decoration: none`). Confirmed live: those anchors have `className: (NONE)`, light-grey color, no underline. (Markdown `[text](url)` links were unaffected — Nextra styles those.)

## Fix
Give the `Portal` anchor a `.sol-portal-link` class and style it in `global.css` to match content links — blue, underlined, hover-clears, plus an external-link `↗` marker (it opens the live portal in a new tab). Dark-mode variant included.

`nx run docs:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)