### PR TITLE
fix(enrollment-portal): remove nested scroll on class-selection season tabs

### DIFF
--- a/libs/angular/classes/class-enrollment/src/lib/components/classes/class-list/class-list.component.css
+++ b/libs/angular/classes/class-enrollment/src/lib/components/classes/class-list/class-list.component.css
@@ -55,3 +55,23 @@
         padding-right: 0 !important;
     }
 }
+
+/*
+ * Let the season tab body scroll with the page instead of creating a nested
+ * scroll region. Material's active tab body defaults to `overflow-y: auto`,
+ * and the 17.5px content padding makes the content box slightly taller than
+ * the flex-sized body — producing a permanent inner scrollbar. Growing the
+ * body/wrapper to fit content removes the mismatch.
+ */
+:host ::ng-deep .mat-mdc-tab-body-wrapper {
+    overflow: visible;
+}
+:host ::ng-deep .mat-mdc-tab-body.mat-mdc-tab-body-active {
+    overflow: visible;
+    height: auto;
+}
+:host ::ng-deep .mat-mdc-tab-body.mat-mdc-tab-body-active
+    .mat-mdc-tab-body-content {
+    overflow: visible;
+    height: auto;
+}


### PR DESCRIPTION
## Problem

On the main enrollment **Class Selection** page, the active season tab body (`.mat-mdc-tab-body`) had its own nested scroll region, separate from the page scroll — producing a thin permanent inner scrollbar.

## Root cause

Angular Material gives the active tab body `overflow-y: auto` by default. The global `.mat-mdc-tab-body-content { padding: 17.5px }` rule (`apps/enrollment-portal/src/custom-theme.scss`) makes the content box ~35px taller than the flex-sized tab body, so `overflow: auto` renders a permanent tiny scrollbar.

Confirmed against the live DOM: the only nested scroller was `.mat-mdc-tab-body-active` with `scrollHeight 14713` vs `clientHeight 14678` — exactly the 2×17.5px content padding.

## Fix

Scoped `:host ::ng-deep` override in `class-list.component.css` (the component that owns the season tab group): set the active tab body, its content, and the wrapper to `overflow: visible; height: auto` so the body grows to fit its content and scrolls with the page.

## Verification

Applied the CSS live via injected styles: nested scroller removed, `scrollHeight === clientHeight` (14678), and no clipped/overhanging content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)