### PR TITLE
fix(enrollment): record additional-option purchases on legacy inline classes

### DIFF
--- a/apps/functions-integration-tests/src/tests/roster-additional-options.spec.ts
+++ b/apps/functions-integration-tests/src/tests/roster-additional-options.spec.ts
@@ -1,0 +1,281 @@
+import {
+    createTestUser,
+    clearAuthEmulator,
+    clearFirestoreEmulator,
+    setFirestoreDoc,
+    callFunction,
+    FirestoreRef,
+    FirestoreTimestamp,
+} from '../utils';
+import type { TestUser } from '../utils';
+import { ADMIN_USER, NON_ADMIN_USER } from '../fixtures';
+import { EMULATOR_CONFIG, getFunctionUrl } from '../utils/emulator-config';
+
+const SEMESTER_ID = 'test-semester-roster';
+
+const futureDate = new Date();
+futureDate.setFullYear(futureDate.getFullYear() + 1);
+
+const pastDate = new Date();
+pastDate.setFullYear(pastDate.getFullYear() - 1);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+// cost: 0 keeps enrollment free so the flow never touches Braintree.
+function makeClassDoc(
+    overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+    return {
+        name: 'Roster Test Class',
+        description: 'Test',
+        live: true,
+        cost: 0,
+        location: 'Room A',
+        weekday: 'Monday',
+        daily_times: '9-12',
+        class_type: 'Standard',
+        grade_range_start: 1,
+        grade_range_end: 5,
+        thumbnailUrl: '',
+        paused_for_enrollment: false,
+        for_information_only: false,
+        max_student_size: 12,
+        min_student_size: 5,
+        instructors: [],
+        students: [],
+        start: new FirestoreTimestamp(pastDate),
+        end: new FirestoreTimestamp(futureDate),
+        registration_end_date: new FirestoreTimestamp(futureDate),
+        ...overrides,
+    };
+}
+
+function makeStudentForm(overrides: Record<string, unknown> = {}) {
+    return {
+        firstName: 'Alex',
+        lastName: 'Rivera',
+        birthdate: '2015-01-01',
+        pronouns: 'they/them',
+        school: 'Test School',
+        tshirtSize: 'M',
+        notes: '',
+        contactEmail: 'parent@test.com',
+        contactFirstName: 'Parent',
+        contactLastName: 'Rivera',
+        studentEmail: '',
+        contactPhone: '555-0100',
+        studentPhone: '',
+        address: '123 Test St',
+        city: 'Testville',
+        state: 'CO',
+        zip: '80000',
+        deetBugspray: false,
+        naturalBugspray: false,
+        sunscreen: true,
+        photography: 'yes',
+        guardians: [
+            {
+                guardianName: 'Parent Rivera',
+                guardianRelationship: 'Parent',
+                guardianPhone: '555-0100',
+                guardianEmail: 'parent@test.com',
+                guardianResidesWithStudent: true,
+            },
+        ],
+        pickupCodeword: 'sunflower',
+        authorizedForPickup: [],
+        emergencyContacts: [
+            {
+                name: 'Emergency Contact',
+                relationship: 'Aunt',
+                phone: '555-0200',
+            },
+        ],
+        weightImperial: 80,
+        heightFeet: 4,
+        heightInches: 6,
+        doctorName: 'Dr. Test',
+        doctorPhone: '555-0300',
+        insuranceCompany: 'Test Insurance',
+        insuranceId: 'INS-001',
+        doesNotHaveInsurance: false,
+        hasLifeThreateningAllergies: false,
+        allergies: undefined,
+        medications: [],
+        authorizedToAdministerMedication: true,
+        medicalNotes: undefined,
+        ...overrides,
+    };
+}
+
+async function enroll(
+    classId: string,
+    optionIds: string[],
+    idToken: string
+): Promise<{ status: number; success?: boolean }> {
+    const result = await callFunction<unknown, { success?: boolean }>({
+        functionName: 'enroll',
+        data: {
+            selectedClasses: [{ id: classId, semesterId: SEMESTER_ID }],
+            student: makeStudentForm(),
+            releaseSignatures: [],
+            discountCodes: [],
+            userCostsToSelectedClassIds: {},
+            additionalOptionIdsByClassId: { [classId]: optionIds },
+            expectedTotal: 0,
+        },
+        idToken,
+    });
+    return { status: result.status, success: result.data?.success };
+}
+
+async function fetchRosterHtml(
+    classId: string,
+    idToken: string
+): Promise<{ status: number; html: string }> {
+    const url = `${getFunctionUrl('roster')}?classId=${encodeURIComponent(
+        classId
+    )}&semesterId=${encodeURIComponent(SEMESTER_ID)}`;
+
+    const response = await fetch(url, {
+        headers: {
+            Origin: EMULATOR_CONFIG.origin,
+            Authorization: `Bearer ${idToken}`,
+        },
+    });
+
+    const body = (await response.json()) as { data?: { html?: string } };
+    return { status: response.status, html: body.data?.html ?? '' };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('Roster additional options (enroll → roster)', () => {
+    let adminUser: TestUser;
+    let enrollmentUser: TestUser;
+
+    beforeAll(async () => {
+        await clearAuthEmulator();
+        adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
+        enrollmentUser = await createTestUser(
+            NON_ADMIN_USER.email,
+            NON_ADMIN_USER.password
+        );
+    });
+
+    beforeEach(async () => {
+        await clearFirestoreEmulator();
+        await setFirestoreDoc('admins', adminUser.uid, {
+            userId: adminUser.uid,
+            email: adminUser.email,
+        });
+    });
+
+    afterAll(async () => {
+        await clearAuthEmulator();
+        await clearFirestoreEmulator();
+    });
+
+    // Regression guard for the storage refactor (#185). Options moved from an
+    // inline class field to an `additional_options` subcollection, but the
+    // enrollment write path (addStudentToClass) only wrote to the subcollection
+    // — so for classes whose options still live inline (the shape production
+    // summer2026 classes have), a paid add-on like early dropoff was silently
+    // dropped and never reached the roster.
+    it('records an inline (legacy) option purchase onto the roster', async () => {
+        await setFirestoreDoc(
+            `semesters/${SEMESTER_ID}/classes`,
+            'legacy-class',
+            makeClassDoc({
+                additional_options: [
+                    {
+                        id: 'opt-early-drop',
+                        description: 'Early Dropoff',
+                        cost: 0,
+                        students: [],
+                    },
+                ],
+            })
+        );
+
+        const enrolled = await enroll(
+            'legacy-class',
+            ['opt-early-drop'],
+            enrollmentUser.idToken
+        );
+        expect(enrolled.status).toBe(200);
+        expect(enrolled.success).toBe(true);
+
+        const { status, html } = await fetchRosterHtml(
+            'legacy-class',
+            adminUser.idToken
+        );
+        expect(status).toBe(200);
+        expect(html).toContain('Rivera');
+        expect(html).toContain('Early Dropoff');
+    });
+
+    // End-to-end coverage of the current (subcollection) storage shape.
+    it('records a subcollection option purchase onto the roster', async () => {
+        await setFirestoreDoc(
+            `semesters/${SEMESTER_ID}/classes`,
+            'subcoll-class',
+            makeClassDoc()
+        );
+        await setFirestoreDoc(
+            `semesters/${SEMESTER_ID}/classes/subcoll-class/additional_options`,
+            'opt-after-care',
+            { description: 'After Care', cost: 0, students: [] }
+        );
+
+        const enrolled = await enroll(
+            'subcoll-class',
+            ['opt-after-care'],
+            enrollmentUser.idToken
+        );
+        expect(enrolled.status).toBe(200);
+        expect(enrolled.success).toBe(true);
+
+        const { status, html } = await fetchRosterHtml(
+            'subcoll-class',
+            adminUser.idToken
+        );
+        expect(status).toBe(200);
+        expect(html).toContain('Rivera');
+        expect(html).toContain('After Care');
+    });
+
+    // An option nobody bought must not leak onto the roster.
+    it('does not show an option the enrolled student did not purchase', async () => {
+        await setFirestoreDoc(
+            `semesters/${SEMESTER_ID}/classes`,
+            'no-purchase-class',
+            makeClassDoc({
+                additional_options: [
+                    {
+                        id: 'opt-early-drop',
+                        description: 'Early Dropoff',
+                        cost: 0,
+                        students: [],
+                    },
+                ],
+            })
+        );
+
+        const enrolled = await enroll(
+            'no-purchase-class',
+            [],
+            enrollmentUser.idToken
+        );
+        expect(enrolled.status).toBe(200);
+        expect(enrolled.success).toBe(true);
+
+        const { status, html } = await fetchRosterHtml(
+            'no-purchase-class',
+            adminUser.idToken
+        );
+        expect(status).toBe(200);
+        expect(html).toContain('Rivera');
+        expect(html).not.toContain('Early Dropoff');
+    });
+});

--- a/libs/firebase/classes/class-repository/src/lib/class.repository.ts
+++ b/libs/firebase/classes/class-repository/src/lib/class.repository.ts
@@ -181,6 +181,9 @@ export class ClassRepository {
         const additionalOptionsCollection =
             classRef.collection('additional_options');
 
+        let inlineOptions = classData?.additional_options;
+        let inlineOptionsChanged = false;
+
         for (const optionId of additionalOptionIds) {
             const optionRef = additionalOptionsCollection.doc(optionId);
             const optionDoc = await optionRef.get();
@@ -197,7 +200,27 @@ export class ClassRepository {
                         students: updatedOptionStudents,
                     });
                 }
+            } else if (inlineOptions?.some((o) => o.id === optionId)) {
+                // Legacy option stored inline on the class doc (predates the
+                // additional_options subcollection). Mirror the subcollection
+                // logic against the inline array so the option lives in one
+                // place per class and the roster stays consistent.
+                inlineOptions = inlineOptions.map((option) => {
+                    if (option.id !== optionId) return option;
+                    const existing = option.students ?? [];
+                    const filtered = existing.filter(
+                        (ref) => ref.id !== studentRef.id
+                    );
+                    if (filtered.length !== existing.length) {
+                        inlineOptionsChanged = true;
+                    }
+                    return { ...option, students: filtered };
+                });
             }
+        }
+
+        if (inlineOptionsChanged && inlineOptions) {
+            await classRef.update({ additional_options: inlineOptions });
         }
     }
 
@@ -237,6 +260,9 @@ export class ClassRepository {
         const additionalOptionsCollection =
             classRef.collection('additional_options');
 
+        let inlineOptions = classData?.additional_options;
+        let inlineOptionsChanged = false;
+
         for (const optionId of additionalOptionIds) {
             const optionRef = additionalOptionsCollection.doc(optionId);
             const optionDoc = await optionRef.get();
@@ -254,7 +280,25 @@ export class ClassRepository {
                         students: [...currentStudents, studentRef],
                     });
                 }
+            } else if (inlineOptions?.some((o) => o.id === optionId)) {
+                // Legacy option stored inline on the class doc (predates the
+                // additional_options subcollection). Without this branch the
+                // purchase is silently dropped — it never reaches the class,
+                // so it never appears on the roster.
+                inlineOptions = inlineOptions.map((option) => {
+                    if (option.id !== optionId) return option;
+                    const existing = option.students ?? [];
+                    if (existing.some((ref) => ref.id === studentRef.id)) {
+                        return option;
+                    }
+                    inlineOptionsChanged = true;
+                    return { ...option, students: [...existing, studentRef] };
+                });
             }
+        }
+
+        if (inlineOptionsChanged && inlineOptions) {
+            await classRef.update({ additional_options: inlineOptions });
         }
     }
 }


### PR DESCRIPTION
## Problem

Parents reported that early-dropoff registrations they'd paid for weren't showing on class rosters. Reported feature: purchasing an add-on should surface it on the roster.

## Root cause

Additional options moved from an inline `additional_options` field to an `additional_options` subcollection (#185). The enrollment write path — `ClassRepository.addStudentToClass` / `removeStudentFromClass` — was updated to write to the subcollection, but only the subcollection:

```ts
const optionDoc = await optionRef.get();
if (optionDoc.exists) { /* add student */ }   // silently skipped otherwise
```

Classes whose options still live in the **legacy inline field** (the shape current classes have) hit the `optionDoc.exists === false` branch, so the purchase was **silently dropped** — recorded on the `enrollment` record but never mirrored onto the class, so it never reached the roster.

The read/roster path was already correct (`getHydratedDocuments` merges the subcollection), so it is unchanged.

## Fix

`addStudentToClass` / `removeStudentFromClass` now fall back to updating the inline `additional_options` array when the option isn't in the subcollection — recording the purchase wherever the class actually keeps its options.

## Tests

New end-to-end integration test (`enroll` → `roster`) covering:
- inline (legacy) option → roster ✅ (**fails without this fix — reproduces the bug**)
- subcollection option → roster ✅
- an unpurchased option must not leak onto the roster ✅

Verified against the Firebase emulator (caching disabled): the inline test fails on `main`, all 114 integration tests pass with the fix.

## Follow-ups (not in this PR)

- **Data backfill:** already-affected families are recorded on their `enrollment` docs but not on the class options; they need a one-time additive backfill to appear on rosters. Script prepared separately (dry-run by default).
- **Related latent read gap:** `get-classes-for-admin` and `get-class-for-edit` read the inline field from a raw doc `.get()` with no subcollection merge, so the admin edit form likely won't show options for subcollection-only classes. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)