### PR TITLE
fix(class-management): read additional options from subcollection in admin views

### DIFF
--- a/apps/functions-integration-tests/src/tests/additional-options-subcollection.spec.ts
+++ b/apps/functions-integration-tests/src/tests/additional-options-subcollection.spec.ts
@@ -122,10 +122,7 @@ describe('Additional Options Subcollection', () => {
 
     beforeAll(async () => {
         await clearAuthEmulator();
-        adminUser = await createTestUser(
-            ADMIN_USER.email,
-            ADMIN_USER.password
-        );
+        adminUser = await createTestUser(ADMIN_USER.email, ADMIN_USER.password);
         await setFirestoreDoc('admins', adminUser.uid, {
             userId: adminUser.uid,
             email: adminUser.email,
@@ -603,9 +600,7 @@ describe('Additional Options Subcollection', () => {
 
             expect(result.status).toBe(200);
             const classes = result.data![SEMESTER_ID].classes;
-            const testClass = classes.find(
-                (c) => c.id === 'class-roster-test'
-            );
+            const testClass = classes.find((c) => c.id === 'class-roster-test');
             expect(testClass).toBeDefined();
             expect(testClass!.additionalOptions).toHaveLength(1);
             expect(testClass!.additionalOptions![0].description).toBe(
@@ -614,6 +609,137 @@ describe('Additional Options Subcollection', () => {
             expect(testClass!.additionalOptions![0].studentsIds).toContain(
                 'student-1'
             );
+        });
+    });
+
+    // createClass stores options only in the subcollection, so every class made
+    // through the admin UI is subcollection-only. The admin read paths must
+    // surface those options — otherwise the edit form loads empty and a save
+    // wipes the options (data loss), and the copy/detail views show nothing.
+    describe('admin read paths surface subcollection options', () => {
+        async function createClassWithOptions(
+            name: string,
+            additionalOptions: Array<{
+                id: string;
+                description: string;
+                cost: number;
+            }>
+        ): Promise<string> {
+            const result = await callFunction<
+                CreateClassRequest,
+                CreateClassResponse
+            >({
+                functionName: 'createClass',
+                data: makeCreateClassRequest({ name, additionalOptions }),
+                idToken: adminUser.idToken,
+            });
+            expect(result.status).toBe(200);
+            return result.data!.classId;
+        }
+
+        it('getClassForEdit returns options for a subcollection-only class', async () => {
+            const classId = await createClassWithOptions('Editable Class', [
+                { id: 'opt-a', description: 'Before care', cost: 25 },
+                { id: 'opt-b', description: 'After care', cost: 30 },
+            ]);
+
+            const edit = await callFunction<
+                { semesterId: string; classId: string },
+                {
+                    class: {
+                        additionalOptions?: Array<{
+                            id: string;
+                            description: string;
+                            cost: number;
+                        }>;
+                    };
+                }
+            >({
+                functionName: 'getClassForEdit',
+                data: { semesterId: SEMESTER_ID, classId },
+                idToken: adminUser.idToken,
+            });
+
+            expect(edit.status).toBe(200);
+            const options = edit.data!.class.additionalOptions ?? [];
+            expect(options.map((o) => o.description).sort()).toEqual([
+                'After care',
+                'Before care',
+            ]);
+        });
+
+        it('getClassesForAdmin returns options for a subcollection-only class', async () => {
+            const classId = await createClassWithOptions('Listed Class', [
+                { id: 'opt-list', description: 'Early dropoff', cost: 15 },
+            ]);
+
+            const result = await callFunction<
+                { semesterId: string },
+                {
+                    classes: Array<{
+                        id: string;
+                        additionalOptions?: Array<{
+                            id: string;
+                            description: string;
+                            cost: number;
+                        }>;
+                    }>;
+                }
+            >({
+                functionName: 'getClassesForAdmin',
+                data: { semesterId: SEMESTER_ID },
+                idToken: adminUser.idToken,
+            });
+
+            expect(result.status).toBe(200);
+            const listed = result.data!.classes.find((c) => c.id === classId);
+            expect(listed?.additionalOptions).toEqual([
+                { id: 'opt-list', description: 'Early dropoff', cost: 15 },
+            ]);
+        });
+
+        // The data-loss regression: load a subcollection-only class through the
+        // edit form and save it straight back. The option must survive.
+        it('editing a subcollection-only class does not wipe its options', async () => {
+            const classId = await createClassWithOptions('Round Trip Class', [
+                { id: 'opt-keep', description: 'Early dropoff', cost: 25 },
+            ]);
+
+            // Simulate the admin edit form: read via getClassForEdit, then save
+            // back exactly what the form received.
+            const edit = await callFunction<
+                { semesterId: string; classId: string },
+                {
+                    class: {
+                        additionalOptions?: Array<{
+                            id: string;
+                            description: string;
+                            cost: number;
+                        }>;
+                    };
+                }
+            >({
+                functionName: 'getClassForEdit',
+                data: { semesterId: SEMESTER_ID, classId },
+                idToken: adminUser.idToken,
+            });
+
+            await callFunction<UpdateClassRequest, UpdateClassResponse>({
+                functionName: 'updateClass',
+                data: {
+                    ...makeCreateClassRequest({ name: 'Round Trip Class' }),
+                    classId,
+                    additionalOptions: edit.data!.class.additionalOptions ?? [],
+                },
+                idToken: adminUser.idToken,
+            });
+
+            const options = await listFirestoreCollection(
+                `semesters/${SEMESTER_ID}/classes/${classId}/additional_options`
+            );
+            expect(options).toHaveLength(1);
+            expect(options[0].id).toBe('opt-keep');
+            expect(options[0].fields.description).toBe('Early dropoff');
         });
     });
 });

--- a/libs/firebase/enrollment-functions/get-class-for-edit/src/lib/get-class-for-edit.ts
+++ b/libs/firebase/enrollment-functions/get-class-for-edit/src/lib/get-class-for-edit.ts
@@ -78,6 +78,37 @@ export const getClassForEdit = Functions.endpoint
             (data.units as admin.firestore.DocumentReference[]) || [];
         const unitIds = unitRefs.map((ref) => ref.id);
 
+        // Options live in the `additional_options` subcollection for classes
+        // created/edited via the admin UI; fall back to the legacy inline field
+        // for classes that predate that. Reading only the inline field here
+        // loaded the edit form with no options, and saving then wiped them.
+        const optionsSnapshot = await db
+            .collection(
+                `semesters/${semesterId}/classes/${classId}/additional_options`
+            )
+            .get();
+        const additionalOptions =
+            optionsSnapshot.docs.length > 0
+                ? optionsSnapshot.docs.map((optionDoc) => {
+                      const option = optionDoc.data();
+                      return {
+                          id: optionDoc.id,
+                          description: option.description,
+                          cost: option.cost,
+                      };
+                  })
+                : data.additional_options?.map(
+                      (opt: {
+                          id: string;
+                          description: string;
+                          cost: number;
+                      }) => ({
+                          id: opt.id,
+                          description: opt.description,
+                          cost: opt.cost,
+                      })
+                  );
+
         const classForEdit: ClassForEdit = {
             id: classDoc.id,
             name: data.name || '',
@@ -104,13 +135,7 @@ export const getClassForEdit = Functions.endpoint
             thumbnailUrl: data.thumbnailUrl,
             unitIds: unitIds.length > 0 ? unitIds : undefined,
             ageGroup: data.age_group || undefined,
-            additionalOptions: data.additional_options?.map(
-                (opt: { id: string; description: string; cost: number }) => ({
-                    id: opt.id,
-                    description: opt.description,
-                    cost: opt.cost,
-                })
-            ),
+            additionalOptions,
         };
 
         response.send({ class: classForEdit });

--- a/libs/firebase/enrollment-functions/get-classes-for-admin/src/lib/get-classes-for-admin.ts
+++ b/libs/firebase/enrollment-functions/get-classes-for-admin/src/lib/get-classes-for-admin.ts
@@ -78,6 +78,34 @@ export const getClassesForAdmin = Functions.endpoint
                     (data.students as admin.firestore.DocumentReference[]) ||
                     [];
 
+                // Options live in the `additional_options` subcollection for
+                // classes created/edited via the admin UI; fall back to the
+                // legacy inline field for classes that predate that.
+                const optionsSnapshot = await doc.ref
+                    .collection('additional_options')
+                    .get();
+                const additionalOptions =
+                    optionsSnapshot.docs.length > 0
+                        ? optionsSnapshot.docs.map((optionDoc) => {
+                              const option = optionDoc.data();
+                              return {
+                                  id: optionDoc.id,
+                                  description: option.description,
+                                  cost: option.cost,
+                              };
+                          })
+                        : data.additional_options?.map(
+                              (opt: {
+                                  id: string;
+                                  description: string;
+                                  cost: number;
+                              }) => ({
+                                  id: opt.id,
+                                  description: opt.description,
+                                  cost: opt.cost,
+                              })
+                          );
+
                 return {
                     id: doc.id,
                     name: data.name || '',
@@ -105,17 +133,7 @@ export const getClassesForAdmin = Functions.endpoint
                         : (data.paused_for_enrollment ?? false),
                     forInformationOnly: data.for_information_only ?? false,
                     thumbnailUrl: data.thumbnailUrl,
-                    additionalOptions: data.additional_options?.map(
-                        (opt: {
-                            id: string;
-                            description: string;
-                            cost: number;
-                        }) => ({
-                            id: opt.id,
-                            description: opt.description,
-                            cost: opt.cost,
-                        })
-                    ),
+                    additionalOptions,
                 };
             })
         );


### PR DESCRIPTION
## Problem

`getClassForEdit` and `getClassesForAdmin` read additional options only from the legacy **inline** `additional_options` field. But `createClass`/`updateClass` store options in the `additional_options` **subcollection** (and `updateClass` deletes the inline field), so every class created or edited through the admin UI is subcollection-only.

Consequences for subcollection-only classes:
- **Data loss:** the edit form (`class-form.component.ts:1446`) and the copy-class dialog load these classes with **no options**, and saving then syncs an empty option set — silently **wiping** the options.
- Admin list/detail views show no options for these classes.

## Fix

Both functions now read the `additional_options` subcollection and fall back to the inline field for classes that predate the migration — the same pattern `classesBySemester` already uses.

## Tests

Added to `additional-options-subcollection.spec.ts`:
- `getClassForEdit` returns options for a subcollection-only class
- `getClassesForAdmin` returns options for a subcollection-only class
- **edit round-trip does not wipe options** (load via `getClassForEdit` → save via `updateClass`)

All three **fail without this fix** — verified against the emulator, the round-trip left the subcollection empty (`Received length: 0`). With the fix, all 117 integration tests pass.

## Relationship to #296

Sibling of #296 (roster / enrollment write path). Same inline-vs-subcollection split, different surface: #296 fixes the enrollment *write* path for inline classes; this fixes the admin *read* path for subcollection classes. Independent; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)