### PR TITLE
feat(admin-nav): add Admin Guide link to the admin drawer

### DIFF
--- a/libs/angular/header/src/lib/components/admin-drawer-nav.component.ts
+++ b/libs/angular/header/src/lib/components/admin-drawer-nav.component.ts
@@ -103,6 +103,15 @@ import { MatDividerModule } from '@angular/material/divider';
                 <mat-icon matListItemIcon>assignment</mat-icon>
                 Student Units
             </a>
+            <!-- GitHub Pages project URL; redirects to docs.mountainsol.org once #259 lands. -->
+            <a
+                mat-list-item
+                href="https://mountainsolschool.github.io/platform/"
+                target="_blank"
+            >
+                <mat-icon matListItemIcon>menu_book</mat-icon>
+                Admin Guide
+            </a>
             @if (isMedicAdmin()) {
                 <mat-divider></mat-divider>
                 <div class="nav-section">Medic Admin</div>


### PR DESCRIPTION
Adds an **Admin Guide** entry to the admin drawer nav so admins can reach the docs site, matching the existing external **Student Units** link (opens in a new tab).

Points at the GitHub Pages project URL (`https://mountainsolschool.github.io/platform/`) — GitHub Pages redirects it to `docs.mountainsol.org` once the custom domain (#259) is configured, so the link survives that flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)